### PR TITLE
feat: add build flow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,38 @@
+name: Sync Notion Docs
+
+on:
+  workflow_dispatch
+
+jobs:
+  pull-docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun i
+
+      - name: Notion To Markdown
+        run: bun notionToMd
+
+      - name: Commit generated docs
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+          # Stage specific paths (adjust to your generated files)
+          git add docs i18n
+
+          # Commit if there are changes
+          git diff --cached --quiet || git commit -m "chore: update docs from Notion"
+
+          # Push back to the repository
+          git push
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+


### PR DESCRIPTION
The flow basically:
1. runs `bun notionToMd`
2. commits `docs/` and `i18n` and pushes

Unclear if we should push onto a branch and create a PR so there's a review step before publishing. I would say no so that it doesn't depend on tech and non-tech people going into github