### PR TITLE
fix(notion-fetch): preserve callout formatting in admonitions

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,41 @@ GIT_USER=<Your GitHub username> bun deploy
 
 For GitHub Pages hosting, this command conveniently builds the site and pushes to the `gh-pages` branch.
 
+### Customizing Admonition Colors
+
+The site supports custom colors for Notion callouts (admonitions). To modify the color scheme:
+
+1. **Open** `src/css/custom.css`
+2. **Find** the "Custom Admonition Colors" section (around line 85)
+3. **Modify** the hex color values for any admonition type:
+   - `NOTE` (gray Notion callouts): Currently `#e5e4e2` (platinum/silver)
+   - `TIP` (green Notion callouts): Currently `#22c55e` (green)
+   - `INFO` (blue Notion callouts): Currently `#3b82f6` (blue)
+   - `WARNING` (yellow Notion callouts): Currently `#f59e0b` (amber)
+   - `DANGER` (red Notion callouts): Currently `#ef4444` (red)
+   - `CAUTION` (orange Notion callouts): Currently `#f97316` (orange)
+
+**Example**: To change NOTE admonitions to purple:
+```css
+/* NOTE admonitions (gray callouts from Notion) */
+.admonition--note,
+.admonition-note,
+.alert--secondary,
+div[class*="admonition"][class*="note"] {
+  background-color: rgba(147, 51, 234, 0.1) !important;
+  border-left-color: #9333ea !important;
+  border-color: #9333ea !important;
+}
+
+/* Update the corresponding icon color */
+.admonition-note .admonition-icon svg,
+div[class*="admonition"][class*="note"] svg {
+  fill: #9333ea !important;
+}
+```
+
+Changes will be reflected immediately in development mode (`bun dev`).
+
 ### GitHub Actions Workflows
 
 The repository includes several automated workflows for content management:

--- a/scripts/notion-fetch/calloutProcessor.test.ts
+++ b/scripts/notion-fetch/calloutProcessor.test.ts
@@ -59,12 +59,13 @@ describe("calloutProcessor", () => {
         color: "green_background" as const,
       };
 
-      const result = processCalloutBlock(calloutProperties);
+      const result = processCalloutBlock(calloutProperties, {
+        markdownLines: ["👁️ This is a test callout content"],
+      });
 
       expect(result.type).toBe("tip");
       expect(result.title).toBe("👁️");
       expect(result.content).toBe("This is a test callout content");
-      expect(result.hasCustomTitle).toBe(true);
     });
 
     it("should process a callout without icon", () => {
@@ -79,12 +80,13 @@ describe("calloutProcessor", () => {
         color: "blue_background" as const,
       };
 
-      const result = processCalloutBlock(calloutProperties);
+      const result = processCalloutBlock(calloutProperties, {
+        markdownLines: ["This is a callout without icon"],
+      });
 
       expect(result.type).toBe("info");
       expect(result.title).toBeUndefined();
       expect(result.content).toBe("This is a callout without icon");
-      expect(result.hasCustomTitle).toBe(false);
     });
 
     it("should handle different color mappings", () => {
@@ -108,7 +110,9 @@ describe("calloutProcessor", () => {
           color,
         };
 
-        const result = processCalloutBlock(calloutProperties);
+        const result = processCalloutBlock(calloutProperties, {
+          markdownLines: ["Test content"],
+        });
         expect(result.type).toBe(expectedType);
       });
     });
@@ -125,11 +129,41 @@ describe("calloutProcessor", () => {
         color: "default" as const,
       };
 
-      const result = processCalloutBlock(calloutProperties);
+      const result = processCalloutBlock(calloutProperties, {
+        markdownLines: ["**Important Note:**", "This is the content"],
+      });
 
       expect(result.title).toBe("Important Note");
-      expect(result.hasCustomTitle).toBe(true);
       expect(result.content).toBe("This is the content");
+    });
+
+    it("should pull inline title and preserve formatting", () => {
+      const calloutProperties = {
+        rich_text: [
+          {
+            type: "text",
+            text: {
+              content: "**Heads up:** Remember to `bun install` before running",
+            },
+            plain_text:
+              "**Heads up:** Remember to `bun install` before running",
+          },
+        ],
+        color: "yellow_background" as const,
+      };
+
+      const result = processCalloutBlock(calloutProperties, {
+        markdownLines: [
+          "**Heads up:** Remember to `bun install` before running",
+          "- Don't forget to copy the .env file",
+        ],
+      });
+
+      expect(result.type).toBe("warning");
+      expect(result.title).toBe("Heads up");
+      expect(result.content).toBe(
+        "Remember to `bun install` before running\n- Don't forget to copy the .env file"
+      );
     });
 
     it("should handle multiple rich text objects", () => {
@@ -153,7 +187,9 @@ describe("calloutProcessor", () => {
         color: "yellow_background" as const,
       };
 
-      const result = processCalloutBlock(calloutProperties);
+      const result = processCalloutBlock(calloutProperties, {
+        markdownLines: ["🔔 First part second part"],
+      });
 
       expect(result.type).toBe("warning");
       expect(result.title).toBe("🔔");
@@ -167,7 +203,6 @@ describe("calloutProcessor", () => {
         type: "tip" as const,
         title: "💡",
         content: "This is helpful information",
-        hasCustomTitle: true,
       };
 
       const result = calloutToAdmonition(processedCallout);
@@ -180,7 +215,6 @@ describe("calloutProcessor", () => {
         type: "warning" as const,
         title: undefined,
         content: "This is a warning message",
-        hasCustomTitle: false,
       };
 
       const result = calloutToAdmonition(processedCallout);
@@ -193,7 +227,6 @@ describe("calloutProcessor", () => {
         type: "note" as const,
         title: "Empty Note",
         content: "",
-        hasCustomTitle: true,
       };
 
       const result = calloutToAdmonition(processedCallout);
@@ -206,7 +239,6 @@ describe("calloutProcessor", () => {
         type: "info" as const,
         title: undefined,
         content: "Line 1\nLine 2\nLine 3",
-        hasCustomTitle: false,
       };
 
       const result = calloutToAdmonition(processedCallout);
@@ -236,7 +268,9 @@ describe("calloutProcessor", () => {
         },
       };
 
-      const result = convertCalloutToAdmonition(calloutBlock as any);
+      const result = convertCalloutToAdmonition(calloutBlock as any, [
+        "👁️ See screen capture below",
+      ]);
 
       expect(result).toBe(":::tip 👁️\nSee screen capture below\n:::\n");
     });
@@ -256,7 +290,9 @@ describe("calloutProcessor", () => {
         },
       };
 
-      const result = convertCalloutToAdmonition(paragraphBlock as any);
+      const result = convertCalloutToAdmonition(paragraphBlock as any, [
+        "Regular paragraph",
+      ]);
 
       expect(result).toBeNull();
     });

--- a/scripts/notion-fetch/calloutProcessor.test.ts
+++ b/scripts/notion-fetch/calloutProcessor.test.ts
@@ -1,0 +1,276 @@
+import { describe, it, expect } from "vitest";
+import {
+  CALLOUT_COLOR_MAPPING,
+  processCalloutBlock,
+  calloutToAdmonition,
+  convertCalloutToAdmonition,
+  isCalloutBlock,
+} from "./calloutProcessor";
+
+describe("calloutProcessor", () => {
+  describe("CALLOUT_COLOR_MAPPING", () => {
+    it("should map all expected Notion colors to Docusaurus admonition types", () => {
+      expect(CALLOUT_COLOR_MAPPING.blue_background).toBe("info");
+      expect(CALLOUT_COLOR_MAPPING.yellow_background).toBe("warning");
+      expect(CALLOUT_COLOR_MAPPING.red_background).toBe("danger");
+      expect(CALLOUT_COLOR_MAPPING.green_background).toBe("tip");
+      expect(CALLOUT_COLOR_MAPPING.gray_background).toBe("note");
+      expect(CALLOUT_COLOR_MAPPING.orange_background).toBe("caution");
+      expect(CALLOUT_COLOR_MAPPING.purple_background).toBe("note");
+      expect(CALLOUT_COLOR_MAPPING.pink_background).toBe("note");
+      expect(CALLOUT_COLOR_MAPPING.brown_background).toBe("note");
+      expect(CALLOUT_COLOR_MAPPING.default).toBe("note");
+    });
+  });
+
+  describe("isCalloutBlock", () => {
+    it("should identify callout blocks correctly", () => {
+      const calloutBlock = { type: "callout", id: "test" };
+      const paragraphBlock = { type: "paragraph", id: "test" };
+
+      expect(isCalloutBlock(calloutBlock as any)).toBe(true);
+      expect(isCalloutBlock(paragraphBlock as any)).toBe(false);
+    });
+  });
+
+  describe("processCalloutBlock", () => {
+    it("should process a basic callout with emoji icon", () => {
+      const calloutProperties = {
+        rich_text: [
+          {
+            type: "text" as const,
+            text: { content: "This is a test callout content", link: null },
+            annotations: {
+              bold: false,
+              italic: false,
+              strikethrough: false,
+              underline: false,
+              code: false,
+              color: "default" as const,
+            },
+            plain_text: "This is a test callout content",
+            href: null,
+          },
+        ],
+        icon: {
+          type: "emoji" as const,
+          emoji: "👁️",
+        },
+        color: "green_background" as const,
+      };
+
+      const result = processCalloutBlock(calloutProperties);
+
+      expect(result.type).toBe("tip");
+      expect(result.title).toBe("👁️");
+      expect(result.content).toBe("This is a test callout content");
+      expect(result.hasCustomTitle).toBe(true);
+    });
+
+    it("should process a callout without icon", () => {
+      const calloutProperties = {
+        rich_text: [
+          {
+            type: "text",
+            text: { content: "This is a callout without icon" },
+            plain_text: "This is a callout without icon",
+          },
+        ],
+        color: "blue_background" as const,
+      };
+
+      const result = processCalloutBlock(calloutProperties);
+
+      expect(result.type).toBe("info");
+      expect(result.title).toBeUndefined();
+      expect(result.content).toBe("This is a callout without icon");
+      expect(result.hasCustomTitle).toBe(false);
+    });
+
+    it("should handle different color mappings", () => {
+      const testCases = [
+        { color: "red_background" as const, expectedType: "danger" },
+        { color: "yellow_background" as const, expectedType: "warning" },
+        { color: "orange_background" as const, expectedType: "caution" },
+        { color: "gray_background" as const, expectedType: "note" },
+        { color: "purple_background" as const, expectedType: "note" },
+      ];
+
+      testCases.forEach(({ color, expectedType }) => {
+        const calloutProperties = {
+          rich_text: [
+            {
+              type: "text",
+              text: { content: "Test content" },
+              plain_text: "Test content",
+            },
+          ],
+          color,
+        };
+
+        const result = processCalloutBlock(calloutProperties);
+        expect(result.type).toBe(expectedType);
+      });
+    });
+
+    it("should extract title from content with bold formatting", () => {
+      const calloutProperties = {
+        rich_text: [
+          {
+            type: "text",
+            text: { content: "**Important Note:**\nThis is the content" },
+            plain_text: "**Important Note:**\nThis is the content",
+          },
+        ],
+        color: "default" as const,
+      };
+
+      const result = processCalloutBlock(calloutProperties);
+
+      expect(result.title).toBe("Important Note");
+      expect(result.hasCustomTitle).toBe(true);
+      expect(result.content).toBe("This is the content");
+    });
+
+    it("should handle multiple rich text objects", () => {
+      const calloutProperties = {
+        rich_text: [
+          {
+            type: "text",
+            text: { content: "First part " },
+            plain_text: "First part ",
+          },
+          {
+            type: "text",
+            text: { content: "second part" },
+            plain_text: "second part",
+          },
+        ],
+        icon: {
+          type: "emoji" as const,
+          emoji: "🔔",
+        },
+        color: "yellow_background" as const,
+      };
+
+      const result = processCalloutBlock(calloutProperties);
+
+      expect(result.type).toBe("warning");
+      expect(result.title).toBe("🔔");
+      expect(result.content).toBe("First part second part");
+    });
+  });
+
+  describe("calloutToAdmonition", () => {
+    it("should generate correct admonition syntax with title", () => {
+      const processedCallout = {
+        type: "tip" as const,
+        title: "💡",
+        content: "This is helpful information",
+        hasCustomTitle: true,
+      };
+
+      const result = calloutToAdmonition(processedCallout);
+
+      expect(result).toBe(":::tip 💡\nThis is helpful information\n:::\n");
+    });
+
+    it("should generate correct admonition syntax without title", () => {
+      const processedCallout = {
+        type: "warning" as const,
+        title: undefined,
+        content: "This is a warning message",
+        hasCustomTitle: false,
+      };
+
+      const result = calloutToAdmonition(processedCallout);
+
+      expect(result).toBe(":::warning\nThis is a warning message\n:::\n");
+    });
+
+    it("should handle empty content", () => {
+      const processedCallout = {
+        type: "note" as const,
+        title: "Empty Note",
+        content: "",
+        hasCustomTitle: true,
+      };
+
+      const result = calloutToAdmonition(processedCallout);
+
+      expect(result).toBe(":::note Empty Note\n:::\n");
+    });
+
+    it("should preserve multiline content", () => {
+      const processedCallout = {
+        type: "info" as const,
+        title: undefined,
+        content: "Line 1\nLine 2\nLine 3",
+        hasCustomTitle: false,
+      };
+
+      const result = calloutToAdmonition(processedCallout);
+
+      expect(result).toBe(":::info\nLine 1\nLine 2\nLine 3\n:::\n");
+    });
+  });
+
+  describe("convertCalloutToAdmonition", () => {
+    it("should convert a complete callout block to admonition markdown", () => {
+      const calloutBlock = {
+        type: "callout",
+        id: "test-id",
+        callout: {
+          rich_text: [
+            {
+              type: "text",
+              text: { content: "See screen capture below" },
+              plain_text: "See screen capture below",
+            },
+          ],
+          icon: {
+            type: "emoji",
+            emoji: "👁️",
+          },
+          color: "green_background",
+        },
+      };
+
+      const result = convertCalloutToAdmonition(calloutBlock as any);
+
+      expect(result).toBe(":::tip 👁️\nSee screen capture below\n:::\n");
+    });
+
+    it("should return null for non-callout blocks", () => {
+      const paragraphBlock = {
+        type: "paragraph",
+        id: "test-id",
+        paragraph: {
+          rich_text: [
+            {
+              type: "text",
+              text: { content: "Regular paragraph" },
+              plain_text: "Regular paragraph",
+            },
+          ],
+        },
+      };
+
+      const result = convertCalloutToAdmonition(paragraphBlock as any);
+
+      expect(result).toBeNull();
+    });
+
+    it("should return null for callout block without callout properties", () => {
+      const malformedBlock = {
+        type: "callout",
+        id: "test-id",
+        // Missing callout properties
+      };
+
+      const result = convertCalloutToAdmonition(malformedBlock as any);
+
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/scripts/notion-fetch/calloutProcessor.ts
+++ b/scripts/notion-fetch/calloutProcessor.ts
@@ -1,0 +1,237 @@
+import type {
+  BlockObject,
+  RichTextItemResponse,
+} from "@notionhq/client/build/src/api-endpoints";
+
+/**
+ * Notion callout colors mapped to Docusaurus admonition types
+ */
+export const CALLOUT_COLOR_MAPPING = {
+  blue_background: "info",
+  yellow_background: "warning",
+  red_background: "danger",
+  green_background: "tip",
+  gray_background: "note",
+  orange_background: "caution",
+  purple_background: "note",
+  pink_background: "note",
+  brown_background: "note",
+  default: "note",
+} as const;
+
+export type NotionCalloutColor = keyof typeof CALLOUT_COLOR_MAPPING;
+export type DocusaurusAdmonitionType =
+  (typeof CALLOUT_COLOR_MAPPING)[NotionCalloutColor];
+
+/**
+ * Interface for callout block properties
+ */
+export interface CalloutBlockProperties {
+  rich_text: RichTextItemResponse[];
+  icon?: {
+    type: "emoji" | "external" | "file";
+    emoji?: string;
+    external?: { url: string };
+    file?: { url: string };
+  } | null;
+  color: NotionCalloutColor;
+}
+
+/**
+ * Interface for processed callout data
+ */
+export interface ProcessedCallout {
+  type: DocusaurusAdmonitionType;
+  title?: string;
+  content: string;
+  hasCustomTitle: boolean;
+}
+
+/**
+ * Extract emoji or icon from Notion callout icon property
+ */
+function extractIconText(icon?: CalloutBlockProperties["icon"]): string | null {
+  if (!icon) return null;
+
+  if (icon.type === "emoji" && icon.emoji) {
+    return icon.emoji;
+  }
+
+  // For external/file icons, we could potentially download and process them,
+  // but for now, we'll skip them to keep things simple
+  return null;
+}
+
+/**
+ * Extract plain text content from Notion rich text array
+ */
+function extractTextFromRichText(richText: RichTextItemResponse[]): string {
+  return richText
+    .map((textObj) => {
+      if (textObj.type === "text") {
+        return textObj.text.content;
+      } else if (textObj.type === "mention") {
+        return textObj.plain_text || "";
+      } else if (textObj.type === "equation") {
+        return textObj.equation.expression || "";
+      }
+      return textObj.plain_text || "";
+    })
+    .join("");
+}
+
+/**
+ * Generate Docusaurus admonition title from callout properties
+ */
+function generateTitle(
+  icon: string | null,
+  content: string,
+  admonitionType: DocusaurusAdmonitionType
+): { title: string | undefined; hasCustomTitle: boolean } {
+  // If we have an icon, use it as the title
+  if (icon) {
+    return { title: icon, hasCustomTitle: true };
+  }
+
+  // For certain types, we might want to extract the first line as title
+  const lines = content.split("\n");
+  const firstLine = lines[0]?.trim();
+
+  // If the first line looks like a title (short, with formatting indicators)
+  if (firstLine && firstLine.length < 100 && lines.length > 1) {
+    // Check if first line has bold formatting or ends with colon
+    if (firstLine.includes("**") || firstLine.endsWith(":")) {
+      return {
+        title: firstLine.replace(/\*\*/g, "").replace(/:$/, "").trim(),
+        hasCustomTitle: true,
+      };
+    }
+  }
+
+  // Use default Docusaurus admonition titles
+  return { title: undefined, hasCustomTitle: false };
+}
+
+/**
+ * Process a Notion callout block into Docusaurus admonition format
+ */
+export function processCalloutBlock(
+  calloutProperties: CalloutBlockProperties
+): ProcessedCallout {
+  // Map Notion color to Docusaurus admonition type
+  const admonitionType =
+    CALLOUT_COLOR_MAPPING[calloutProperties.color] ||
+    CALLOUT_COLOR_MAPPING.default;
+
+  // Extract text content
+  const content = extractTextFromRichText(calloutProperties.rich_text);
+
+  // Extract icon
+  const icon = extractIconText(calloutProperties.icon);
+
+  // Generate title
+  const { title, hasCustomTitle } = generateTitle(
+    icon,
+    content,
+    admonitionType
+  );
+
+  // Handle content processing for custom titles
+  let finalContent = content;
+  if (hasCustomTitle && title) {
+    // Use simple string matching instead of regex for security
+    const lines = content.split("\n");
+    const firstLine = lines[0]?.trim() || "";
+
+    // Clean the first line by removing markdown formatting for comparison
+    const cleanedFirstLine = firstLine.replace(/\*\*/g, "").replace(/:$/, "").trim().toLowerCase();
+    const cleanedTitle = title.toLowerCase();
+    
+    // Check if first line matches the title (with or without formatting)
+    if (cleanedFirstLine === cleanedTitle) {
+      // Remove the first line and rejoin
+      finalContent = lines.slice(1).join("\n").trim();
+    } else if (cleanedFirstLine.startsWith(cleanedTitle)) {
+      // Remove the title part from the first line using string operations
+      let processedLine = firstLine.replace(/\*\*/g, ""); // Remove bold formatting
+      
+      // Remove the title text (case-insensitive)
+      const titleIndex = processedLine.toLowerCase().indexOf(title.toLowerCase());
+      if (titleIndex === 0) {
+        processedLine = processedLine.slice(title.length);
+      }
+      
+      // Remove colon and whitespace at the beginning
+      processedLine = processedLine.replace(/^:\s*/, "").trim();
+      
+      if (processedLine) {
+        lines[0] = processedLine;
+        finalContent = lines.join("\n").trim();
+      } else {
+        finalContent = lines.slice(1).join("\n").trim();
+      }
+    }
+  }
+
+  return {
+    type: admonitionType,
+    title,
+    content: finalContent,
+    hasCustomTitle,
+  };
+}
+
+/**
+ * Convert processed callout to Docusaurus admonition markdown syntax
+ */
+export function calloutToAdmonition(
+  processedCallout: ProcessedCallout
+): string {
+  const { type, title, content } = processedCallout;
+
+  // Build the admonition opening
+  let admonition = `:::${type}`;
+  if (title) {
+    admonition += ` ${title}`;
+  }
+  admonition += "\n";
+
+  // Add content (preserve any existing markdown formatting)
+  if (content) {
+    admonition += content + "\n";
+  }
+
+  // Close the admonition
+  admonition += ":::\n";
+
+  return admonition;
+}
+
+/**
+ * Check if a block is a callout block
+ */
+export function isCalloutBlock(
+  block: BlockObject
+): block is BlockObject & { type: "callout" } {
+  return block.type === "callout";
+}
+
+/**
+ * Main processing function to convert a callout block to admonition markdown
+ */
+export function convertCalloutToAdmonition(block: BlockObject): string | null {
+  if (!isCalloutBlock(block)) {
+    return null;
+  }
+
+  // Type assertion since we've confirmed this is a callout block
+  const calloutBlock = block as any;
+  const calloutProperties: CalloutBlockProperties = calloutBlock.callout;
+
+  if (!calloutProperties) {
+    return null;
+  }
+
+  const processedCallout = processCalloutBlock(calloutProperties);
+  return calloutToAdmonition(processedCallout);
+}

--- a/scripts/notion-fetch/calloutProcessor.ts
+++ b/scripts/notion-fetch/calloutProcessor.ts
@@ -112,8 +112,12 @@ function stripIconFromLines(lines: string[], icon: string): string[] {
   const leading = firstLine.match(/^\s*/)?.[0] ?? "";
   const trimmed = firstLine.slice(leading.length);
 
-  // Do not strip when the first non-space char starts a code fence, inline code, or blockquote
-  if (/^`{1,3}/.test(trimmed) || trimmed.startsWith(">")) {
+  // Do not strip when the first non-space char starts a code fence, inline code, blockquote, or admonition fence
+  if (
+    /^`{1,3}/.test(trimmed) ||
+    trimmed.startsWith(">") ||
+    trimmed.startsWith(":::")
+  ) {
     return lines;
   }
 

--- a/scripts/notion-fetch/calloutProcessor.ts
+++ b/scripts/notion-fetch/calloutProcessor.ts
@@ -138,7 +138,7 @@ function stripIconFromLines(lines: string[], icon: string): string[] {
   // - whitespace after icon, or
   // - optional punctuation then at least one space, to avoid stripping "👁️is"
   const iconPattern = new RegExp(
-    `^${escapedIcon}(?:\\s+|\\s*[:\\-–—]\\s+)`,
+    `^${escapedIcon}(?:\\s+|\\s*[:\\-–—]\\s*)`,
     "u"
   );
 
@@ -177,7 +177,8 @@ function extractTitleFromLines(lines: string[]): {
   }
 
   // Conservative plain "Title: content" case (short, single-phrase title)
-  const colonMatch = trimmed.match(/^([A-Z][^:\s]{0,49})\s*:\s*(.*)$/u);
+  // Allow any leading Unicode letter and mixed case, short single-phrase title before colon
+  const colonMatch = trimmed.match(/^([\p{L}][^:\n]{0,49}?)\s*:\s*(.*)$/u);
   if (colonMatch) {
     const titleCandidate = colonMatch[1].trim();
     const sameLineRemainder = colonMatch[2]?.trimStart() ?? "";

--- a/scripts/notion-fetch/calloutProcessor.ts
+++ b/scripts/notion-fetch/calloutProcessor.ts
@@ -134,7 +134,13 @@ function stripIconFromLines(lines: string[], icon: string): string[] {
 
   // Build a safe pattern for the exact icon, followed by optional punctuation and space
   const escapedIcon = icon.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  const iconPattern = new RegExp(`^${escapedIcon}(?:\\s*[:\\-]\\s*|\\s+)`, "u");
+  // Require either:
+  // - whitespace after icon, or
+  // - optional punctuation then at least one space, to avoid stripping "👁️is"
+  const iconPattern = new RegExp(
+    `^${escapedIcon}(?:\\s+|\\s*[:\\-–—]\\s+)`,
+    "u"
+  );
 
   if (!iconPattern.test(trimmed)) {
     return lines;
@@ -170,10 +176,10 @@ function extractTitleFromLines(lines: string[]): {
     }
   }
 
-  // Plain "Title: content" case
-  const colonMatch = trimmed.match(/^([^:]{1,100})\s*:\s*(.*)$/u);
+  // Conservative plain "Title: content" case (short, single-phrase title)
+  const colonMatch = trimmed.match(/^([A-Z][^:\s]{0,49})\s*:\s*(.*)$/u);
   if (colonMatch) {
-    const titleCandidate = colonMatch[1].trim().replace(/:$/u, "");
+    const titleCandidate = colonMatch[1].trim();
     const sameLineRemainder = colonMatch[2]?.trimStart() ?? "";
     const hasContent = sameLineRemainder.length > 0 || restLines.length > 0;
     if (titleCandidate && hasContent) {

--- a/scripts/notion-fetch/calloutProcessor.ts
+++ b/scripts/notion-fetch/calloutProcessor.ts
@@ -124,31 +124,37 @@ function extractTitleFromLines(lines: string[]): {
   title?: string;
   contentLines: string[];
 } {
-  if (lines.length === 0) {
-    return { contentLines: [] };
-  }
+  if (lines.length === 0) return { contentLines: [] };
 
   const [firstLine, ...restLines] = lines;
   const trimmed = firstLine.trim();
 
-  const boldMatch = trimmed.match(/^\*\*(.+?)\*\*\s*:?(.*)$/u);
+  // Match **Title** optionally followed by a colon and optional same-line content
+  const boldMatch = trimmed.match(/^\*\*(.+?)\*\*\s*:?\s*(.*)$/u);
   if (boldMatch) {
-    const title = boldMatch[1].trim().replace(/:$/u, "");
-    if (title) {
-      const remainder = boldMatch[2].trimStart();
-      const contentLines = remainder ? [remainder, ...restLines] : restLines;
+    const rawTitle = boldMatch[1].trim();
+    // Remove a single trailing colon from title if present
+    const title = rawTitle.replace(/:$/u, "");
+    const sameLineRemainder = boldMatch[2]?.trimStart() ?? "";
+    const hasContent = sameLineRemainder.length > 0 || restLines.length > 0;
+    if (title && hasContent) {
+      const contentLines = sameLineRemainder
+        ? [sameLineRemainder, ...restLines]
+        : restLines;
       return { title, contentLines };
     }
   }
 
-  const colonMatch = trimmed.match(/^([^:]{1,100})\s*:(.*)$/u);
+  // Plain "Title: content" case
+  const colonMatch = trimmed.match(/^([^:]{1,100})\s*:\s*(.*)$/u);
   if (colonMatch) {
     const titleCandidate = colonMatch[1].trim().replace(/:$/u, "");
-    const remainder = colonMatch[2].trimStart();
-    const hasContent = remainder.length > 0 || restLines.length > 0;
-
+    const sameLineRemainder = colonMatch[2]?.trimStart() ?? "";
+    const hasContent = sameLineRemainder.length > 0 || restLines.length > 0;
     if (titleCandidate && hasContent) {
-      const contentLines = remainder ? [remainder, ...restLines] : restLines;
+      const contentLines = sameLineRemainder
+        ? [sameLineRemainder, ...restLines]
+        : restLines;
       return { title: titleCandidate, contentLines };
     }
   }

--- a/scripts/notion-fetch/calloutProcessor.ts
+++ b/scripts/notion-fetch/calloutProcessor.ts
@@ -111,8 +111,8 @@ function stripIconFromLines(lines: string[], icon: string): string[] {
   const [firstLine, ...rest] = lines;
   const trimmed = firstLine.trimStart();
 
-  // Do not strip when the first non-space char starts a code fence or inline code
-  if (/^`{1,3}/.test(trimmed)) {
+  // Do not strip when the first non-space char starts a code fence, inline code, or blockquote
+  if (/^`{1,3}/.test(trimmed) || trimmed.startsWith(">")) {
     return lines;
   }
 
@@ -141,8 +141,8 @@ function extractTitleFromLines(lines: string[]): {
   const boldMatch = trimmed.match(/^\*\*(.+?)\*\*\s*:?\s*(.*)$/u);
   if (boldMatch) {
     const rawTitle = boldMatch[1].trim();
-    // Remove a single trailing colon from title if present
-    const title = rawTitle.replace(/:$/u, "");
+    // Remove trailing punctuation commonly used in headings
+    const title = rawTitle.replace(/[:\.!?\uFF1A\u3002\uFF01\uFF1F]+$/u, "");
     const sameLineRemainder = boldMatch[2]?.trimStart() ?? "";
     const hasContent = sameLineRemainder.length > 0 || restLines.length > 0;
     if (title && hasContent) {

--- a/scripts/notion-fetch/calloutProcessor.ts
+++ b/scripts/notion-fetch/calloutProcessor.ts
@@ -103,23 +103,21 @@ function normalizeLines(
 }
 
 function stripIconFromLines(lines: string[], icon: string): string[] {
-  if (lines.length === 0) {
-    return lines;
-  }
+  if (lines.length === 0) return lines;
 
   const [firstLine, ...rest] = lines;
   const trimmed = firstLine.trimStart();
 
-  if (!trimmed.startsWith(icon)) {
+  // Build a safe pattern for the exact icon, followed by optional punctuation and space
+  const escapedIcon = icon.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const iconPattern = new RegExp(`^${escapedIcon}(?:\\s*[:\\-]\\s*|\\s+)`, "u");
+
+  if (!iconPattern.test(trimmed)) {
     return lines;
   }
 
-  const remainder = trimmed.slice(icon.length).trimStart();
-  if (remainder) {
-    return [remainder, ...rest];
-  }
-
-  return rest;
+  const remainder = trimmed.replace(iconPattern, "");
+  return remainder ? [remainder, ...rest] : rest;
 }
 
 function extractTitleFromLines(lines: string[]): {

--- a/scripts/notion-fetch/calloutProcessor.ts
+++ b/scripts/notion-fetch/calloutProcessor.ts
@@ -109,7 +109,8 @@ function stripIconFromLines(lines: string[], icon: string): string[] {
   if (lines.length === 0) return lines;
 
   const [firstLine, ...rest] = lines;
-  const trimmed = firstLine.trimStart();
+  const leading = firstLine.match(/^\s*/)?.[0] ?? "";
+  const trimmed = firstLine.slice(leading.length);
 
   // Do not strip when the first non-space char starts a code fence, inline code, or blockquote
   if (/^`{1,3}/.test(trimmed) || trimmed.startsWith(">")) {
@@ -125,7 +126,7 @@ function stripIconFromLines(lines: string[], icon: string): string[] {
   }
 
   const remainder = trimmed.replace(iconPattern, "");
-  return remainder ? [remainder, ...rest] : rest;
+  return remainder ? [`${leading}${remainder}`, ...rest] : rest;
 }
 
 function extractTitleFromLines(lines: string[]): {
@@ -135,6 +136,7 @@ function extractTitleFromLines(lines: string[]): {
   if (lines.length === 0) return { contentLines: [] };
 
   const [firstLine, ...restLines] = lines;
+  const leading = firstLine.match(/^\s*/)?.[0] ?? "";
   const trimmed = firstLine.trim();
 
   // Match **Title** optionally followed by a colon and optional same-line content
@@ -147,7 +149,7 @@ function extractTitleFromLines(lines: string[]): {
     const hasContent = sameLineRemainder.length > 0 || restLines.length > 0;
     if (title && hasContent) {
       const contentLines = sameLineRemainder
-        ? [sameLineRemainder, ...restLines]
+        ? [`${leading}${sameLineRemainder}`, ...restLines]
         : restLines;
       return { title, contentLines };
     }
@@ -161,7 +163,7 @@ function extractTitleFromLines(lines: string[]): {
     const hasContent = sameLineRemainder.length > 0 || restLines.length > 0;
     if (titleCandidate && hasContent) {
       const contentLines = sameLineRemainder
-        ? [sameLineRemainder, ...restLines]
+        ? [`${leading}${sameLineRemainder}`, ...restLines]
         : restLines;
       return { title: titleCandidate, contentLines };
     }

--- a/scripts/notion-fetch/calloutProcessor.ts
+++ b/scripts/notion-fetch/calloutProcessor.ts
@@ -138,7 +138,7 @@ function stripIconFromLines(lines: string[], icon: string): string[] {
   // - whitespace after icon, or
   // - optional punctuation then at least one space, to avoid stripping "👁️is"
   const iconPattern = new RegExp(
-    `^${escapedIcon}(?:\\s+|\\s*[:\\-–—]\\s*)`,
+    `^${escapedIcon}(?:\\s+|\\s*[:\\-–—]\\s+)`,
     "u"
   );
 

--- a/scripts/notion-fetch/calloutProcessor.ts
+++ b/scripts/notion-fetch/calloutProcessor.ts
@@ -71,21 +71,32 @@ function extractIconText(icon?: CalloutBlockProperties["icon"]): string | null {
  * Extract plain text content from Notion rich text array
  */
 function extractTextFromRichText(richText: RichTextItemResponse[]): string {
-  return richText
-    .map((textObj) => {
-      if (typeof textObj.plain_text === "string") {
-        return textObj.plain_text;
-      }
-      if (textObj.type === "equation") {
-        return textObj.equation.expression || "";
-      }
-      // Fallback
-      if (textObj.type === "text") {
-        return textObj.text.content;
-      }
-      return "";
-    })
-    .join("");
+  const parts = richText.map((textObj) => {
+    if (typeof (textObj as any).plain_text === "string") {
+      return (textObj as any).plain_text as string;
+    }
+    if (textObj.type === "equation") {
+      return textObj.equation.expression || "";
+    }
+    if (textObj.type === "text") {
+      return textObj.text.content;
+    }
+    return "";
+  });
+  const result: string[] = [];
+  for (let i = 0; i < parts.length; i++) {
+    const cur = parts[i];
+    if (!cur) continue;
+    if (
+      result.length > 0 &&
+      !/\s$/.test(result[result.length - 1]) &&
+      !/^\s/.test(cur)
+    ) {
+      result.push(" ");
+    }
+    result.push(cur);
+  }
+  return result.join("");
 }
 
 function normalizeLines(

--- a/scripts/notion-fetch/generateBlocks.ts
+++ b/scripts/notion-fetch/generateBlocks.ts
@@ -105,7 +105,11 @@ function processCalloutsInMarkdown(
       continue;
     }
 
-    const admonitionLines = admonitionMarkdown.trimEnd().split("\n");
+    const leadingWhitespace = lines[match.start].match(/^\s*/)?.[0] ?? "";
+    const admonitionLines = admonitionMarkdown
+      .trimEnd()
+      .split("\n")
+      .map((l) => (l.length ? `${leadingWhitespace}${l}` : l));
     const replaceCount = match.end - match.start + 1;
     lines.splice(match.start, replaceCount, ...admonitionLines);
     searchIndex = match.start + admonitionLines.length;

--- a/scripts/notion-fetch/generateBlocks.ts
+++ b/scripts/notion-fetch/generateBlocks.ts
@@ -105,6 +105,22 @@ function processCalloutsInMarkdown(
       continue;
     }
 
+    // Guard: avoid replacing inside code fences or existing admonitions
+    const isWithinFenceOrAdmonition = (() => {
+      let inFence = false;
+      let inAdmonition = false;
+      for (let i = 0; i < match.start; i++) {
+        const ln = lines[i].trim();
+        if (/^```/.test(ln)) inFence = !inFence;
+        if (/^:::[a-z]+/i.test(ln)) inAdmonition = true;
+        if (/^:::$/.test(ln)) inAdmonition = false;
+      }
+      return inFence || inAdmonition;
+    })();
+    if (isWithinFenceOrAdmonition) {
+      continue;
+    }
+
     const leadingWhitespace = lines[match.start].match(/^\s*/)?.[0] ?? "";
     const admonitionLinesRaw = admonitionMarkdown.trimEnd().split("\n");
     const admonitionLines = admonitionLinesRaw.map((l) =>

--- a/scripts/notion-fetch/generateBlocks.ts
+++ b/scripts/notion-fetch/generateBlocks.ts
@@ -107,13 +107,9 @@ function processCalloutsInMarkdown(
 
     const leadingWhitespace = lines[match.start].match(/^\s*/)?.[0] ?? "";
     const admonitionLinesRaw = admonitionMarkdown.trimEnd().split("\n");
-    const admonitionLines = admonitionLinesRaw.map((l, idx) => {
-      const isFence = idx === 0 || idx === admonitionLinesRaw.length - 1;
-      if (isFence) {
-        return l;
-      }
-      return l.length ? `${leadingWhitespace}${l}` : l;
-    });
+    const admonitionLines = admonitionLinesRaw.map((l) =>
+      l.length ? `${leadingWhitespace}${l}` : l
+    );
     const replaceCount = match.end - match.start + 1;
     lines.splice(match.start, replaceCount, ...admonitionLines);
     searchIndex = match.start + admonitionLines.length;
@@ -146,7 +142,9 @@ function normalizeForMatch(text: string): string {
   let stripped = nfkc;
   const graphemes = Array.from(stripped);
   if (graphemes.length > 0 && /\p{Extended_Pictographic}/u.test(graphemes[0])) {
-    stripped = stripped.slice(graphemes[0].length).replace(/^[\s:;\-–—]+/u, "");
+    // Remove first grapheme safely
+    stripped = graphemes.slice(1).join("");
+    stripped = stripped.replace(/^[\s:;\-–—]+/u, "");
   }
 
   return stripped.replace(/\s+/g, " ").trim();

--- a/scripts/notion-fetch/generateBlocks.ts
+++ b/scripts/notion-fetch/generateBlocks.ts
@@ -107,15 +107,25 @@ function processCalloutsInMarkdown(
 
     // Guard: avoid replacing inside code fences or existing admonitions
     const isWithinFenceOrAdmonition = (() => {
-      let inFence = false;
+      let fenceDelim: string | null = null; // ``` or ~~~
       let inAdmonition = false;
       for (let i = 0; i < match.start; i++) {
-        const ln = lines[i].trim();
-        if (/^```/.test(ln)) inFence = !inFence;
+        const raw = lines[i];
+        const ln = raw.trim();
+        // detect start/end of fences with same delimiter
+        const fenceMatch = ln.match(/^(```+|~~~+)(.*)?$/);
+        if (fenceMatch) {
+          const delim = fenceMatch[1];
+          if (!fenceDelim) {
+            fenceDelim = delim;
+          } else if (fenceDelim === delim) {
+            fenceDelim = null;
+          }
+        }
         if (/^:::[a-z]+/i.test(ln)) inAdmonition = true;
         if (/^:::$/.test(ln)) inAdmonition = false;
       }
-      return inFence || inAdmonition;
+      return fenceDelim !== null || inAdmonition;
     })();
     if (isWithinFenceOrAdmonition) {
       continue;

--- a/scripts/notion-fetch/generateBlocks.ts
+++ b/scripts/notion-fetch/generateBlocks.ts
@@ -131,8 +131,10 @@ function extractTextFromCalloutBlock(block: any): string {
 }
 
 function normalizeForMatch(text: string): string {
-  // Only normalize whitespace; preserve inline markdown formatting and casing for accurate matching
-  return text.replace(/\s+/g, " ").trim();
+  // Normalize Unicode to reduce variant mismatches (e.g., emoji, punctuation)
+  const nfkc =
+    typeof text.normalize === "function" ? text.normalize("NFKC") : text;
+  return nfkc.replace(/\s+/g, " ").trim();
 }
 
 function findMatchingBlockquote(

--- a/scripts/notion-fetch/generateBlocks.ts
+++ b/scripts/notion-fetch/generateBlocks.ts
@@ -160,11 +160,9 @@ function findMatchingBlockquote(
     }
     end -= 1;
 
+    // Remove leading '>' markers while preserving inner indentation
     const contentLines = blockLines.map((line) =>
-      line
-        .replace(/^>\s?/, "")
-        .replace(/^(\s*>+\s*)+/g, "")
-        .trimStart()
+      line.replace(/^(\s*>+\s?)/, "")
     );
     const normalizedContent = normalizeForMatch(contentLines.join(" "));
 

--- a/scripts/notion-fetch/generateBlocks.ts
+++ b/scripts/notion-fetch/generateBlocks.ts
@@ -131,8 +131,8 @@ function extractTextFromCalloutBlock(block: any): string {
 }
 
 function normalizeForMatch(text: string): string {
-  // Only normalize whitespace; preserve inline markdown formatting for accurate matching
-  return text.replace(/\s+/g, " ").trim().toLowerCase();
+  // Only normalize whitespace; preserve inline markdown formatting and casing for accurate matching
+  return text.replace(/\s+/g, " ").trim();
 }
 
 function findMatchingBlockquote(

--- a/scripts/notion-fetch/generateBlocks.ts
+++ b/scripts/notion-fetch/generateBlocks.ts
@@ -131,7 +131,14 @@ function extractTextFromCalloutBlock(block: any): string {
 }
 
 function normalizeForMatch(text: string): string {
-  return text.replace(/\s+/g, " ").trim().toLowerCase();
+  // Remove common markdown markers that shouldn't affect matching
+  const withoutMd = text
+    .replace(/`([^`]+)`/g, "$1") // inline code
+    .replace(/\*\*([^*]+)\*\*/g, "$1") // bold
+    .replace(/\*([^*]+)\*/g, "$1") // italics
+    .replace(/__([^_]+)__/g, "$1") // underline style
+    .replace(/~~([^~]+)~~/g, "$1"); // strikethrough
+  return withoutMd.replace(/\s+/g, " ").trim().toLowerCase();
 }
 
 function findMatchingBlockquote(
@@ -153,7 +160,12 @@ function findMatchingBlockquote(
     }
     end -= 1;
 
-    const contentLines = blockLines.map((line) => line.replace(/^>\s?/, ""));
+    const contentLines = blockLines.map((line) =>
+      line
+        .replace(/^>\s?/, "")
+        .replace(/^(\s*>+\s*)+/g, "")
+        .trimStart()
+    );
     const normalizedContent = normalizeForMatch(contentLines.join(" "));
 
     if (normalizedContent.includes(normalizedSearch)) {

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -81,3 +81,106 @@
   color: var(--ifm-color-content-secondary);
   font-size: 0.9rem;
 }
+
+/* 
+ * Custom Admonition Colors
+ * 
+ * To change colors, simply modify the hex values below:
+ * - Border: The left border and icon color
+ * - Background: Semi-transparent background (using rgba for opacity)
+ * 
+ * Available admonition types: note, tip, info, warning, danger, caution
+ */
+
+/* NOTE - Platinum/Silver theme */
+.admonition,
+.alert,
+div[class*="admonition"] {
+  /* Default fallback - will be overridden by specific types below */
+}
+
+/* NOTE admonitions (gray callouts from Notion) */
+.admonition--note,
+.admonition-note,
+.alert--secondary,
+div[class*="admonition"][class*="note"] {
+  background-color: rgba(229, 228, 226, 0.3) !important;
+  border-left-color: #e5e4e2 !important;
+  border-color: #e5e4e2 !important;
+}
+
+/* TIP admonitions (green callouts) */
+.admonition--tip,
+.admonition-tip,
+div[class*="admonition"][class*="tip"] {
+  background-color: rgba(34, 197, 94, 0.1) !important;
+  border-left-color: #22c55e !important;
+  border-color: #22c55e !important;
+}
+
+/* INFO admonitions (blue callouts) */
+.admonition--info,
+.admonition-info,
+div[class*="admonition"][class*="info"] {
+  background-color: rgba(59, 130, 246, 0.1) !important;
+  border-left-color: #3b82f6 !important;
+  border-color: #3b82f6 !important;
+}
+
+/* WARNING admonitions (yellow callouts) */
+.admonition--warning,
+.admonition-warning,
+div[class*="admonition"][class*="warning"] {
+  background-color: rgba(245, 158, 11, 0.1) !important;
+  border-left-color: #f59e0b !important;
+  border-color: #f59e0b !important;
+}
+
+/* DANGER admonitions (red callouts) */
+.admonition--danger,
+.admonition-danger,
+div[class*="admonition"][class*="danger"] {
+  background-color: rgba(239, 68, 68, 0.1) !important;
+  border-left-color: #ef4444 !important;
+  border-color: #ef4444 !important;
+}
+
+/* CAUTION admonitions (orange callouts) */
+.admonition--caution,
+.admonition-caution,
+div[class*="admonition"][class*="caution"] {
+  background-color: rgba(249, 115, 22, 0.1) !important;
+  border-left-color: #f97316 !important;
+  border-color: #f97316 !important;
+}
+
+/* Icon colors - match border colors */
+.admonition-note .admonition-icon svg,
+div[class*="admonition"][class*="note"] svg {
+  fill: #e5e4e2 !important;
+}
+
+.admonition-tip .admonition-icon svg,
+div[class*="admonition"][class*="tip"] svg {
+  fill: #22c55e !important;
+}
+
+.admonition-info .admonition-icon svg,
+div[class*="admonition"][class*="info"] svg {
+  fill: #3b82f6 !important;
+}
+
+.admonition-warning .admonition-icon svg,
+div[class*="admonition"][class*="warning"] svg {
+  fill: #f59e0b !important;
+}
+
+.admonition-danger .admonition-icon svg,
+div[class*="admonition"][class*="danger"] svg {
+  fill: #ef4444 !important;
+}
+
+.admonition-caution .admonition-icon svg,
+div[class*="admonition"][class*="caution"] svg {
+  fill: #f97316 !important;
+}


### PR DESCRIPTION
### **User description**
## Summary
- convert callout processing to consume raw markdown lines so admonitions keep the original formatting and icons
- replace blockquote matching in generateBlocks with a deterministic line-based search using Notion block types
- expand callout unit tests to cover inline titles, icons, and conversion with provided markdown context

Resolves #17

## Testing
- bunx eslint scripts/notion-fetch/calloutProcessor.ts
- bunx eslint scripts/notion-fetch/generateBlocks.ts # surfaces existing security plugin warnings
- bunx eslint scripts/notion-fetch/calloutProcessor.test.ts
- bunx vitest run scripts/notion-fetch/calloutProcessor.test.ts


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Convert Notion callouts to admonitions

- Map colors to Docusaurus variants

- Add CSS theme for admonitions

- Add comprehensive unit tests


___

### Diagram Walkthrough


```mermaid
flowchart LR
  NotionBlocks["Notion blocks (API)"] -- fetchNotionBlocks --> generateBlocks["generateBlocks.ts"]
  generateBlocks -- detect callouts --> calloutProcessor["calloutProcessor.ts"]
  calloutProcessor -- map colors/titles/icons --> AdmonitionMD["Admonition markdown :::type"]
  AdmonitionMD -- replace blockquotes --> MarkdownOut["Final markdown"]
  MarkdownOut -- styled by --> CSS["custom.css (admonition colors)"]
  Tests["calloutProcessor.test.ts"] -- validate logic --> calloutProcessor
  README["README.md"] -- document customization --> CSS
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>calloutProcessor.test.ts</strong><dd><code>Add comprehensive tests for callout processing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/notion-fetch/calloutProcessor.test.ts

<ul><li>Add unit tests for color mapping and detection<br> <li> Test title/icon extraction and multiline content<br> <li> Validate admonition markdown rendering<br> <li> Cover conversion and non-callout scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/digidem/comapeo-docs/pull/29/files#diff-6840acfdaa54f955e769336dfbd0cbd95c87376cfbb22eac9e8793933191b32e">+312/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>calloutProcessor.ts</strong><dd><code>Implement callout-to-admonition conversion logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/notion-fetch/calloutProcessor.ts

<ul><li>Implement Notion color to admonition mapping<br> <li> Extract icon/title, preserve content formatting<br> <li> Convert callouts to admonition markdown<br> <li> Provide helpers for matching and processing</ul>


</details>


  </td>
  <td><a href="https://github.com/digidem/comapeo-docs/pull/29/files#diff-bc6340dd3cccd9746f69db72d1f6e7f0942c51158135b99bf8db24f2d22af537">+296/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>generateBlocks.ts</strong><dd><code>Integrate callout processing into markdown pipeline</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/notion-fetch/generateBlocks.ts

<ul><li>Fetch raw blocks and find callouts<br> <li> Replace matching blockquotes with admonitions<br> <li> Avoid code fences/admonitions during replace<br> <li> Add safe logging and traversal</ul>


</details>


  </td>
  <td><a href="https://github.com/digidem/comapeo-docs/pull/29/files#diff-808a3f4a2b205f780e89e85442d7f006223c080ccfc75a658f3a8522fb9e7450">+224/-0</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>custom.css</strong><dd><code>Add customizable admonition color system</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/css/custom.css

<ul><li>Add themed colors for admonition variants<br> <li> Style borders, backgrounds, and icons<br> <li> Support note, tip, info, warning, danger, caution</ul>


</details>


  </td>
  <td><a href="https://github.com/digidem/comapeo-docs/pull/29/files#diff-44813f307e729042af7e70beff6f32ea63a7941bc100043a49e84d229ea2570f">+103/-0</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document admonition color customization</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Document how to customize admonition colors<br> <li> Provide CSS example for NOTE variant</ul>


</details>


  </td>
  <td><a href="https://github.com/digidem/comapeo-docs/pull/29/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

