### PR TITLE
fix: restore sidebar headings from Notion Title entries

### DIFF
--- a/scripts/notion-fetch/__tests__/integration.test.ts
+++ b/scripts/notion-fetch/__tests__/integration.test.ts
@@ -89,7 +89,7 @@ describe("Notion Fetch Integration Tests", () => {
     expect(togglePage.properties["Element Type"].select.name).toBe("Toggle");
     
     const headingPage = createMockHeadingPage();
-    expect(headingPage.properties["Element Type"].select.name).toBe("Heading");
+    expect(headingPage.properties["Element Type"].select.name).toBe("Title");
   });
 
   it("should handle image processing mock data", async () => {

--- a/scripts/test-utils/notionFixtures.ts
+++ b/scripts/test-utils/notionFixtures.ts
@@ -141,7 +141,7 @@ export const createMockTogglePage = (options: MockNotionPageOptions = {}) => {
 export const createMockHeadingPage = (options: MockNotionPageOptions = {}) => {
   return createMockNotionPage({ 
     ...options, 
-    elementType: "Heading",
+    elementType: "Title",
   });
 };
 


### PR DESCRIPTION
## Summary
- normalize Notion element types so Title/Heading values still set section metadata
- carry pending Title labels into page customProps to render sidebar headers without toggles
- update fixtures and integration tests to expect Element Type "Title"

## Testing
- bunx vitest run scripts/notion-fetch/generateBlocks.test.ts
- bunx vitest run scripts/notion-fetch/__tests__/integration.test.ts
- bun run notion:fetch