### PR TITLE
fix(css): change table cell vertical alignment from middle to top

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -197,3 +197,12 @@ div[class*="admonition"][class*="danger"] svg {
 div[class*="admonition"][class*="caution"] svg {
   fill: #f97316 !important;
 }
+
+/*
+ * Table styling improvements
+ * Issue #33: Fix vertical alignment from middle to top for better readability
+ */
+.theme-doc-markdown table td,
+.theme-doc-markdown table th {
+  vertical-align: top;
+}


### PR DESCRIPTION
## Summary
Fixes table cell vertical alignment to improve readability and scannability of documentation tables.

## Problem
Tables in the documentation were using middle (center) vertical alignment, which made content appear awkwardly positioned when row heights varied. This was particularly problematic for tables with different amounts of text in cells.

## Solution
Changed all table cells (both `td` and `th`) to use `vertical-align: top` in markdown content.

## Changes
- Added CSS rule to `src/css/custom.css` for `.theme-doc-markdown table` cells
- Simple, targeted fix with minimal scope

## Testing
- ✅ CSS formatted with Prettier
- ✅ Pre-commit hooks passed
- ✅ Change is isolated to table styling only

## Visual Impact
Tables will now have content aligned to the top of cells, making them:
- More professional looking
- Easier to scan and read
- Better aligned with standard documentation practices

## Screenshots
See issue #33 for before/after comparison.

Fixes #33