### PR TITLE
fix: render notion soft line breaks

### DIFF
--- a/scripts/notion-fetch/contentSanitizer.test.ts
+++ b/scripts/notion-fetch/contentSanitizer.test.ts
@@ -121,4 +121,42 @@ describe("contentSanitizer", () => {
       expect(result).toBe("[tag](#tag)");
     });
   });
+
+  describe("restoreSoftLineBreaks", () => {
+    it("should convert single newlines between text into <br /> elements", () => {
+      const input = "First line\nSecond line";
+      const result = scriptModule.restoreSoftLineBreaks(input);
+      expect(result).toBe("First line<br />\nSecond line");
+    });
+
+    it("should leave paragraph breaks (double newlines) untouched", () => {
+      const input = "First paragraph\n\nSecond paragraph";
+      const result = scriptModule.restoreSoftLineBreaks(input);
+      expect(result).toBe(input);
+    });
+
+    it("should ignore newlines that start markdown list items", () => {
+      const input = "Intro text\n- list item";
+      const result = scriptModule.restoreSoftLineBreaks(input);
+      expect(result).toBe(input);
+    });
+
+    it("should ignore newlines before numbered list items", () => {
+      const input = "Intro text\n1. First item";
+      const result = scriptModule.restoreSoftLineBreaks(input);
+      expect(result).toBe(input);
+    });
+
+    it("should not modify content inside fenced code blocks", () => {
+      const input = "```js\nconst x = 1;\nconst y = 2;\n```\nOutside";
+      const result = scriptModule.restoreSoftLineBreaks(input);
+      expect(result).toBe(input);
+    });
+
+    it("should normalize unicode line separators into <br /> line breaks", () => {
+      const input = "Line one\u2028Line two";
+      const result = scriptModule.restoreSoftLineBreaks(input);
+      expect(result).toBe("Line one<br />\nLine two");
+    });
+  });
 });

--- a/scripts/notion-fetch/generateBlocks.test.ts
+++ b/scripts/notion-fetch/generateBlocks.test.ts
@@ -69,6 +69,7 @@ vi.mock("./imageProcessor", () => ({
 
 vi.mock("./utils", () => ({
   sanitizeMarkdownContent: vi.fn((content) => content),
+  restoreSoftLineBreaks: vi.fn((content) => content),
   compressImageToFileWithFallback: vi.fn(),
   detectFormatFromBuffer: vi.fn(() => "jpeg"),
   formatFromContentType: vi.fn(() => "jpeg"),

--- a/scripts/notion-fetch/generateBlocks.ts
+++ b/scripts/notion-fetch/generateBlocks.ts
@@ -13,6 +13,7 @@ import chalk from "chalk";
 import { processImage } from "./imageProcessor";
 import {
   sanitizeMarkdownContent,
+  restoreSoftLineBreaks,
   compressImageToFileWithFallback,
   detectFormatFromBuffer,
   formatFromContentType,
@@ -1548,6 +1549,9 @@ export async function generateBlocks(pages, progressCallback) {
 
               // Sanitize content to fix malformed HTML/JSX tags
               markdownString.parent = sanitizeMarkdownContent(
+                markdownString.parent
+              );
+              markdownString.parent = restoreSoftLineBreaks(
                 markdownString.parent
               );
               // Remove duplicate title heading if it exists

--- a/scripts/notion-fetch/utils.ts
+++ b/scripts/notion-fetch/utils.ts
@@ -4,8 +4,11 @@ import os from "node:os";
 import chalk from "chalk";
 import { compressImage } from "./imageCompressor";
 
-// Re-export sanitize so callers have a single utils entrypoint
-export { sanitizeMarkdownContent } from "./contentSanitizer";
+// Re-export sanitize helpers so callers have a single utils entrypoint
+export {
+  sanitizeMarkdownContent,
+  restoreSoftLineBreaks,
+} from "./contentSanitizer";
 
 // Fail-open toggle: defaults to true unless explicitly set to 'false'
 export const SOFT_FAIL: boolean =


### PR DESCRIPTION
## Summary
- add `restoreSoftLineBreaks` to translate Notion soft breaks into `<br />`
- wire the helper into markdown export so Shift+Enter survives publishing
- extend unit coverage and mocks for the new helper

## Testing
- bunx vitest run scripts/notion-fetch/contentSanitizer.test.ts
- bunx vitest run scripts/notion-fetch/generateBlocks.test.ts

Closes #47
