### PR TITLE
feat(notion-fetch): preserve notion spacers

### DIFF
--- a/scripts/notion-fetch/generateBlocks.ts
+++ b/scripts/notion-fetch/generateBlocks.ts
@@ -26,6 +26,8 @@ import { convertCalloutToAdmonition, isCalloutBlock } from "./calloutProcessor";
 import { fetchNotionBlocks } from "../fetchNotionData";
 import { EmojiProcessor } from "./emojiProcessor";
 
+const DOC_SPACER_COMPONENT = "<DocSpacer />";
+
 // Enhanced image handling utilities for robust processing
 interface ImageProcessingResult {
   success: boolean;
@@ -242,6 +244,27 @@ async function logImageFailure(logEntry: any): Promise<void> {
     });
 
   await imageLogWriting;
+}
+
+function trimEdgeDocSpacers(content: string): string {
+  if (!content) {
+    return content;
+  }
+
+  const lines = content.split("\n");
+
+  while (lines.length && lines[0].trim() === DOC_SPACER_COMPONENT) {
+    lines.shift();
+  }
+
+  while (
+    lines.length &&
+    lines[lines.length - 1].trim() === DOC_SPACER_COMPONENT
+  ) {
+    lines.pop();
+  }
+
+  return lines.join("\n");
 }
 
 /**
@@ -1552,7 +1575,7 @@ export async function generateBlocks(pages, progressCallback) {
               );
               // Remove duplicate title heading if it exists
               // The first H1 heading often duplicates the title in Notion exports
-              let contentBody = markdownString.parent;
+              let contentBody = trimEdgeDocSpacers(markdownString.parent);
 
               // Find the first H1 heading pattern at the beginning of the content
               const firstH1Regex = /^\s*# (.+?)(?:\n|$)/;

--- a/src/components/DocSpacer/index.tsx
+++ b/src/components/DocSpacer/index.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+type DocSpacerSize = "sm" | "md" | "lg";
+
+const SIZE_TO_REM: Record<DocSpacerSize, string> = {
+  sm: "0.5rem",
+  md: "1rem",
+  lg: "1.5rem",
+};
+
+export interface DocSpacerProps {
+  size?: DocSpacerSize;
+}
+
+export default function DocSpacer({ size = "md" }: DocSpacerProps) {
+  const height = SIZE_TO_REM[size] ?? SIZE_TO_REM.md;
+
+  return (
+    <div
+      aria-hidden="true"
+      role="presentation"
+      style={{
+        height,
+        width: "100%",
+        margin: 0,
+      }}
+    />
+  );
+}

--- a/src/theme/MDXComponents/index.tsx
+++ b/src/theme/MDXComponents/index.tsx
@@ -1,0 +1,8 @@
+import React from "react";
+import MDXComponents from "@theme-original/MDXComponents";
+import DocSpacer from "@site/src/components/DocSpacer";
+
+export default {
+  ...MDXComponents,
+  DocSpacer,
+};


### PR DESCRIPTION
## Summary
- emit <DocSpacer /> for empty Notion paragraphs so intentional spacers survive export
- trim leading/trailing spacer tokens and wire up DocSpacer MDX component
- cover the transformer with unit tests for empty, nested, and populated paragraphs

## Testing
- bunx eslint scripts/notionClient.ts scripts/notionClient.test.ts src/components/DocSpacer/index.tsx src/theme/MDXComponents/index.tsx --fix
- bunx eslint scripts/notion-fetch/generateBlocks.ts --fix
- bunx vitest run scripts/notionClient.test.ts

Fixes #49