### PR TITLE
Fix Notion database access in deploy workflow

### DIFF
--- a/.github/workflows/create-content-template.yml
+++ b/.github/workflows/create-content-template.yml
@@ -49,6 +49,7 @@ jobs:
         run: bun scripts/notion-create-template "${{ steps.get-title.outputs.title }}"
         env:
           NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+          DATA_SOURCE_ID: ${{ secrets.DATA_SOURCE_ID }}
           DATABASE_ID: ${{ secrets.DATABASE_ID }}
 
       - name: Report Success

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -92,6 +92,7 @@ jobs:
 
             # Export secrets only when needed for regeneration
             export NOTION_API_KEY="${{ secrets.NOTION_API_KEY }}"
+            export DATA_SOURCE_ID="${{ secrets.DATA_SOURCE_ID }}"
             export DATABASE_ID="${{ secrets.DATABASE_ID }}"
             export BASE_URL="/comapeo-docs/"
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -101,6 +101,7 @@ jobs:
         run: bun run notionStatus:publish-production
         env:
           NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+          DATA_SOURCE_ID: ${{ secrets.DATA_SOURCE_ID }}
           DATABASE_ID: ${{ secrets.DATABASE_ID }}
 
       - name: Deployment summary

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -123,6 +123,7 @@ jobs:
         run: bun run notionStatus:draft
         env:
           NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+          DATA_SOURCE_ID: ${{ secrets.DATA_SOURCE_ID }}
           DATABASE_ID: ${{ secrets.DATABASE_ID }}
 
   notify-slack:

--- a/.github/workflows/notion-fetch-test.yml
+++ b/.github/workflows/notion-fetch-test.yml
@@ -50,6 +50,7 @@ jobs:
       - name: Fetch content from Notion
         env:
           NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+          DATA_SOURCE_ID: ${{ secrets.DATA_SOURCE_ID }}
           NOTION_DATABASE_ID: ${{ secrets.DATABASE_ID }}
           BASE_URL: /comapeo-docs/
         run: bun run notion:fetch-all

--- a/.github/workflows/sync-docs.yml
+++ b/.github/workflows/sync-docs.yml
@@ -30,6 +30,7 @@ jobs:
         run: bun notion:fetch
         env:
           NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+          DATA_SOURCE_ID: ${{ secrets.DATA_SOURCE_ID }}
           DATABASE_ID: ${{ secrets.DATABASE_ID }}
           BASE_URL: /comapeo-docs/
 

--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -30,6 +30,7 @@ jobs:
         run: bun notion:translate
         env:
           NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+          DATA_SOURCE_ID: ${{ secrets.DATA_SOURCE_ID }}
           DATABASE_ID: ${{ secrets.DATABASE_ID }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           OPENAI_MODEL: ${{ secrets.OPENAI_MODEL }}
@@ -38,6 +39,7 @@ jobs:
         run: bun run notionStatus:translation
         env:
           NOTION_API_KEY: ${{ secrets.NOTION_API_KEY }}
+          DATA_SOURCE_ID: ${{ secrets.DATA_SOURCE_ID }}
           DATABASE_ID: ${{ secrets.DATABASE_ID }}
 
       - name: Commit translated docs


### PR DESCRIPTION
Resolves database access errors in GitHub Actions by adding DATA_SOURCE_ID environment variable to all Notion-related workflows.

## Problem
- GitHub Actions failing with "object_not_found" error
- Error: "Could not find database with ID: 1d81b081-62d5-81d3-97d0-fbd08ee35a0c"
- Root cause: Notion API v5 requires data_source_id instead of database_id
- DATABASE_ID and DATA_SOURCE_ID may be different values in v5

## Solution
- Added DATA_SOURCE_ID to all workflows that interact with Notion API:
  - deploy-staging.yml (notion status updates)
  - deploy-production.yml (notion status updates)
  - translate-docs.yml (fetch & translate operations)
  - create-content-template.yml (template creation)
  - sync-docs.yml (content synchronization)
  - deploy-pr-preview.yml (preview deployments)
  - notion-fetch-test.yml (test content fetching)

## Required Follow-up
Repository administrators must:
1. Run migration script locally: bun scripts/migration/discoverDataSource.ts
2. Add discovered DATA_SOURCE_ID to GitHub repository secrets
3. Verify workflows run successfully after secret is added

## Technical Details
- Scripts prefer DATA_SOURCE_ID, fall back to DATABASE_ID for backward compatibility
- All workflows now pass both variables to support migration period
- notionClient.ts (lines 338-351) handles the fallback logic
- notion-status/index.ts (lines 177-181) uses DATA_SOURCE_ID preferentially

Related files:
- scripts/notionClient.ts
- scripts/notion-status/index.ts
- scripts/migration/discoverDataSource.ts