### PR TITLE
Fix smart content provisioning error

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -64,8 +64,8 @@ jobs:
             echo "max_pages=5" >> $GITHUB_OUTPUT
             echo "📖 Label detected: Will fetch 5 pages"
           else
-            echo "max_pages=1" >> $GITHUB_OUTPUT
-            echo "📄 Default: Will fetch 1 page (format-testing-remove)"
+            echo "max_pages=5" >> $GITHUB_OUTPUT
+            echo "📄 Default: Will fetch 5 pages for script validation"
           fi
 
       - name: Setup Bun
@@ -193,7 +193,7 @@ jobs:
 
               // Add guidance for full testing if limited
               if (maxPages !== 'all') {
-                contentInfo += '\n\n> 💡 **Tip:** Add label \`fetch-all-pages\` to test with full content, or \`fetch-10-pages\` for 10 pages.';
+                contentInfo += '\n\n> 💡 **Tip:** Add label \`fetch-all-pages\` to test with full content, or \`fetch-10-pages\` for broader coverage.';
               }
             } else {
               contentInfo = '📦 **Content:** From content branch (no script changes)';

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,15 +84,14 @@ The preview workflow automatically chooses the optimal content generation strate
 
 **When script files ARE modified:**
 - Regenerates content from Notion API to validate script changes
-- Default: Fetches 1 page (`format-testing-remove` with diverse content types)
-- Takes ~60s instead of ~30s
+- Default: Fetches 5 pages (provides reliable validation coverage)
+- Takes ~90s instead of ~30s
 
 **Override via PR labels** (when script changes detected):
 
 | Label | Pages Fetched | Est. Time | When to Use |
 |-------|---------------|-----------|-------------|
-| (no label) | 1 page | ~60s | Default - validates most script changes |
-| `fetch-5-pages` | 5 pages | ~90s | Test broader content coverage |
+| (no label) | 5 pages | ~90s | Default - validates most script changes |
 | `fetch-10-pages` | 10 pages | ~2min | Test pagination, multiple content types |
 | `fetch-all-pages` | All (~50-100) | ~8min | Major refactoring, full validation |
 
@@ -104,16 +103,16 @@ gh pr edit <PR#> --add-label "fetch-10-pages"
 # Or add when creating PR
 gh pr create --label "fetch-all-pages" --title "..." --body "..."
 
-# Remove label to go back to default (1 page)
+# Remove label to go back to default (5 pages)
 gh pr edit <PR#> --remove-label "fetch-10-pages"
 ```
 
 **Label recommendations:**
-- Bug fixes → no label (1 page is sufficient)
-- New block type support → `fetch-5-pages`
+- Bug fixes → no label (5 pages is sufficient)
+- New block type support → no label (5 pages covers most cases)
 - Pagination changes → `fetch-10-pages`
 - Major refactoring → `fetch-all-pages`
-- Image processing changes → `fetch-5-pages`
+- Image processing changes → no label (5 pages is sufficient)
 
 **Important notes:**
 - Labels only affect PRs where script changes are detected


### PR DESCRIPTION
Resolves content generation failure when script changes are detected in PR previews.

## Problem
- Smart content provisioning defaulted to fetching only 1 page for script validation
- Single page could be invalid, skipped, or lack required properties
- This caused docs/ directory to remain empty, failing workflow validation
- Error: "Content regeneration failed - docs/ directory is empty or missing"

## Root Cause
When --max-pages 1 is applied:
- If the single page is a sub-page or has invalid properties, it gets skipped
- No markdown files are generated in docs/ directory
- Workflow validation fails

## Solution
- Changed default from 1 page to 5 pages
- Provides more reliable validation coverage
- Still relatively fast (~90s vs ~60s)
- Multiple pages ensure content generation succeeds even if one page is invalid

## Changes
- Updated deploy-pr-preview.yml: max_pages default 1 → 5
- Updated AGENTS.md documentation to reflect new default
- Removed fetch-5-pages from label recommendations (now the default)
- Updated PR comment guidance

## Impact
- More robust script validation in PR previews
- Slightly longer preview generation time (~30s increase)
- Better test coverage for script changes