### PR TITLE
Debug mysterious 't' variable issue

### DIFF
--- a/scripts/notion-fetch/generateBlocks.ts
+++ b/scripts/notion-fetch/generateBlocks.ts
@@ -1028,6 +1028,10 @@ const buildFrontmatter = (
   // Quote the title to handle special characters like & : etc.
   const quotedTitle = quoteYamlValue(pageTitle);
 
+  // Quote keywords and tags to prevent YAML parsing errors
+  const quotedKeywords = keywords.map((k) => quoteYamlValue(k));
+  const quotedTags = tags.map((t) => quoteYamlValue(t));
+
   let frontmatter = `---
 id: doc-${safeSlug}
 title: ${quotedTitle}
@@ -1036,8 +1040,8 @@ sidebar_position: ${sidebarPosition}
 pagination_label: ${quotedTitle}
 custom_edit_url: https://github.com/digidem/comapeo-docs/edit/main/docs/${relativePath}
 keywords:
-${keywords.map((k) => `  - ${k}`).join("\n")}
-tags: [${tags.join(", ")}]
+${quotedKeywords.map((k) => `  - ${k}`).join("\n")}
+tags: [${quotedTags.join(", ")}]
 slug: /${safeSlug}
 last_update:
   date: ${getPublishedDate(page)}


### PR DESCRIPTION
Fixes incomplete YAML frontmatter quoting that was causing GitHub Actions build failures in PR #87 and potentially other PRs that regenerate content.

Problem:
- PR #75 added quoteYamlValue() for titles but missed tags and keywords
- When Notion pages have tags/keywords with special YAML characters (& : # @ [ ] { } etc.), the generated frontmatter becomes invalid YAML
- Docusaurus build fails with "incomplete explicit mapping pair" error
- This affected PR #87 which regenerates content from Notion

Solution:
- Apply quoteYamlValue() to all keywords before generating keyword list
- Apply quoteYamlValue() to all tags before generating tag array
- Ensures all frontmatter values are properly quoted when needed

Example:
Before: tags: [Getting Started & Installation, Privacy & Security] After:  tags: ["Getting Started & Installation", "Privacy & Security"]

Impact:
- Prevents YAML parsing errors for any tags/keywords with special chars
- Fixes GitHub Actions workflow failures on PR previews
- Completes the frontmatter quoting fix started in PR #75

Related: PR #75, PR #87, GitHub Actions run 19388858527