### PR TITLE
Fix mobile TOC z-index layering issue

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -409,6 +409,13 @@ article {
   border-bottom: 1px solid #e8e8e8;
 }
 
+/* Lower z-index on mobile to prevent overlapping the mobile sidebar/menu */
+@media (max-width: 996px) {
+  .theme-doc-breadcrumbs {
+    z-index: 90; /* Below mobile sidebar (typically 200+) */
+  }
+}
+
 /* Refined hover effect - subtle but visible */
 .theme-doc-breadcrumbs:hover {
   background-color: #f8f9fa;


### PR DESCRIPTION
Fixes #105

The sticky breadcrumbs had z-index: 200 which caused them to appear on top of the mobile sidebar/menu when opened. This change adds a media query to reduce the z-index to 90 on mobile viewports (≤996px), allowing the mobile sidebar (typically z-index 200+) to properly overlay the breadcrumbs.

Desktop behavior remains unchanged with z-index: 200 to prevent logo overflow interference.