### PR TITLE
Fix documentation site redirect to 404 page

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,11 +1,13 @@
 import type { ReactNode } from "react";
 import { Redirect } from "@docusaurus/router";
 import useDocusaurusContext from "@docusaurus/useDocusaurusContext";
+import useBaseUrl from "@docusaurus/useBaseUrl";
 
 export default function Home(): ReactNode {
   const { siteConfig } = useDocusaurusContext();
   const defaultDocsPage =
     (siteConfig.customFields?.defaultDocsPage as string) || "introduction";
+  const docsUrl = useBaseUrl(`/docs/${defaultDocsPage}`);
 
-  return <Redirect to={`/docs/${defaultDocsPage}`} />;
+  return <Redirect to={docsUrl} />;
 }


### PR DESCRIPTION
The home page redirect was using an absolute path `/docs/...` which didn't respect the baseUrl configuration. This caused 404 errors when the site was deployed to subdirectories like `/comapeo-docs/` on GitHub Pages and lab URLs.

Now using Docusaurus's useBaseUrl hook to ensure the redirect path is correct regardless of the baseUrl configuration:
- When baseUrl is `/`, redirects to `/docs/introduction`
- When baseUrl is `/comapeo-docs/`, redirects to `/comapeo-docs/docs/introduction`

Fixes the issue where https://digidem.github.io/comapeo-docs/ and https://lab.digital-democracy.org/comapeo-docs/ showed "Page Not Found".