### PR TITLE
Fix breadcrumb scroll-to-top functionality

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -436,6 +436,17 @@ article {
   background-color: #242526;
 }
 
+/* Active breadcrumb (current page) - clickable for scroll-to-top */
+.theme-doc-breadcrumbs .breadcrumbs__item--active,
+.theme-doc-breadcrumbs .breadcrumbs__item--active .breadcrumbs__link {
+  cursor: pointer;
+}
+
+.theme-doc-breadcrumbs .breadcrumbs__item--active:hover .breadcrumbs__link {
+  color: var(--ifm-color-primary);
+  text-decoration: underline;
+}
+
 /*
  * Table of Contents Styling Enhancement
  * Active item with royal blue background and sliding animation


### PR DESCRIPTION
The previous implementation used complex class-based detection that wasn't reliably triggering scroll-to-top when clicking the active breadcrumb.

Key changes:
- Simplified detection: check if breadcrumb item has NO <a> tag (active items are spans, not links) instead of checking for --active class
- Added stopPropagation() to prevent event from bubbling to other handlers
- Separated handlers into clear addBreadcrumbHandler/addSidebarHandler functions
- Added CSS to ensure active breadcrumb shows pointer cursor and visual feedback