### PR TITLE
fix(api-server): ensure fetch-all timeout tests exercise spawn via content task

### DIFF
--- a/scripts/api-server/content-repo.ts
+++ b/scripts/api-server/content-repo.ts
@@ -1,0 +1,21 @@
+import type { JobType } from "./job-tracker";
+
+const CONTENT_MUTATING_JOBS: ReadonlySet<JobType> = new Set([
+  "notion:fetch",
+  "notion:fetch-all",
+  "notion:translate",
+  "notion:status-draft",
+  "notion:status-publish",
+  "notion:status-publish-production",
+]);
+
+export function isContentMutatingJob(jobType: JobType): boolean {
+  return CONTENT_MUTATING_JOBS.has(jobType);
+}
+
+export async function runContentTask<T>(
+  task: (cwd: string) => Promise<T> | T
+): Promise<T> {
+  const safeCwd = process.cwd();
+  return await task(safeCwd);
+}


### PR DESCRIPTION
### Motivation

- Prevent `notion:fetch-all` timeout tests from short-circuiting due to repository/bootstrap behavior and ensure they exercise the spawn/timeout path. 
- Keep timeout-focused test intent (process spawn and kill behavior) separated from git/content-init concerns. 
- Provide a minimal integration hook so mutating jobs can run with a safe working directory when required by tests and runtime logic.

### Description

- Added `scripts/api-server/content-repo.ts` with `isContentMutatingJob(jobType)` and `runContentTask(task)` helpers to classify mutating jobs and execute a callback with a safe `cwd`.
- Updated `scripts/api-server/job-executor.ts` to introduce `executeWithCwd(cwd?)` which performs the `spawn(...)` call, and route content-mutating jobs through `runContentTask(...)` while non-mutating jobs call `executeWithCwd()` directly.
- Updated `scripts/api-server/job-executor-timeout.test.ts` to mock `./content-repo` exports (`isContentMutatingJob` and `runContentTask`), set sensible defaults in `beforeEach`, and assert that `notion:fetch-all` triggers `runContentTask` and still reaches `spawn(...)` so `mockSpawn` assertions remain valid.
- Kept existing timeout logic and behavior unchanged; the change only wraps execution for mutating jobs so tests can focus on timeout behavior rather than repo bootstrap.

### Testing

- Ran formatting: `bunx prettier --write scripts/api-server/job-executor.ts scripts/api-server/job-executor-timeout.test.ts scripts/api-server/content-repo.ts` (succeeded).
- Ran lint fixes: `bunx eslint scripts/api-server/job-executor.ts scripts/api-server/job-executor-timeout.test.ts scripts/api-server/content-repo.ts --fix` (succeeded).
- Ran targeted unit tests: `bunx vitest run scripts/api-server/job-executor-timeout.test.ts`, and the test file passed (`Test Files 1 passed`, `Tests 26 passed`), test run completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d18292a8883278bb200cf74723aa2)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR introduces a minimal integration layer for content-mutating jobs to ensure timeout tests properly exercise the spawn/timeout code path. A new `content-repo.ts` module classifies jobs as content-mutating and provides a `runContentTask` wrapper that executes callbacks with a safe working directory. The `job-executor.ts` refactors spawn logic into an `executeWithCwd` function and conditionally routes mutating jobs through the wrapper. Tests were updated to mock these new dependencies and verify the execution path for `notion:fetch-all` still reaches spawn, ensuring timeout assertions remain valid.

Key changes:
- Added `isContentMutatingJob()` to classify 6 mutating job types (`notion:fetch`, `notion:fetch-all`, `notion:translate`, and status workflows)
- Introduced `runContentTask()` wrapper providing safe `cwd` for content operations
- Refactored job executor to call `executeWithCwd(cwd?)` conditionally based on job classification
- Updated timeout tests with proper mocks to prevent short-circuiting and maintain spawn coverage

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- Clean refactoring with focused scope - introduces abstraction layer without changing timeout behavior, comprehensive test coverage maintained, all existing tests pass, follows repository patterns
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/api-server/content-repo.ts | New file introducing helper functions to classify mutating jobs and provide safe working directory for content operations |
| scripts/api-server/job-executor.ts | Refactored spawn logic into `executeWithCwd` function and routes content-mutating jobs through `runContentTask` wrapper |
| scripts/api-server/job-executor-timeout.test.ts | Added mocks for content-repo exports and updated test assertions to verify `notion:fetch-all` properly exercises spawn path |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant JobExecutor
    participant ContentRepo
    participant ChildProcess

    Client->>JobExecutor: executeJob(jobType, context, options)
    JobExecutor->>JobExecutor: Create executeWithCwd function
    
    alt Content Mutating Job (e.g., notion:fetch-all)
        JobExecutor->>ContentRepo: isContentMutatingJob(jobType)
        ContentRepo-->>JobExecutor: true
        JobExecutor->>ContentRepo: runContentTask(callback)
        ContentRepo->>ContentRepo: Get safeCwd = process.cwd()
        ContentRepo->>JobExecutor: Execute callback(safeCwd)
        JobExecutor->>ChildProcess: executeWithCwd(safeCwd)
        ChildProcess->>ChildProcess: spawn(script, args, {cwd: safeCwd})
    else Non-Mutating Job
        JobExecutor->>ContentRepo: isContentMutatingJob(jobType)
        ContentRepo-->>JobExecutor: false
        JobExecutor->>ChildProcess: executeWithCwd()
        ChildProcess->>ChildProcess: spawn(script, args, {cwd: undefined})
    end
    
    ChildProcess-->>JobExecutor: Process output/completion
    JobExecutor-->>Client: Job result
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->