### PR TITLE
fix(api-server): harden content-repo lock & resolve scripts from project root

### DIFF
--- a/scripts/api-server/content-repo.test.ts
+++ b/scripts/api-server/content-repo.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { openMock, rmMock } = vi.hoisted(() => ({
+  openMock: vi.fn(),
+  rmMock: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", async () => {
+  const actual =
+    await vi.importActual<typeof import("node:fs/promises")>(
+      "node:fs/promises"
+    );
+
+  return {
+    ...actual,
+    open: openMock,
+    rm: rmMock,
+  };
+});
+
+import { acquireRepoLock } from "./content-repo";
+
+function createErrnoError(
+  code: string,
+  message: string
+): NodeJS.ErrnoException {
+  const error = new Error(message) as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+}
+
+describe("acquireRepoLock", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    rmMock.mockResolvedValue(undefined);
+  });
+
+  it("retries when lock contention returns EEXIST", async () => {
+    const closeMock = vi.fn().mockResolvedValue(undefined);
+
+    openMock
+      .mockRejectedValueOnce(createErrnoError("EEXIST", "already locked"))
+      .mockRejectedValueOnce(createErrnoError("EEXIST", "already locked"))
+      .mockResolvedValue({ close: closeMock });
+
+    const lockPromise = acquireRepoLock("/tmp/test.lock");
+
+    await vi.advanceTimersByTimeAsync(400);
+
+    const lock = await lockPromise;
+    expect(openMock).toHaveBeenCalledTimes(3);
+
+    await lock.release();
+
+    expect(closeMock).toHaveBeenCalledTimes(1);
+    expect(rmMock).toHaveBeenCalledWith("/tmp/test.lock", { force: true });
+  });
+
+  it("fails fast for non-EEXIST lock errors", async () => {
+    openMock.mockRejectedValueOnce(
+      createErrnoError("EACCES", "permission denied")
+    );
+
+    await expect(acquireRepoLock("/tmp/forbidden.lock")).rejects.toThrow(
+      "Failed to acquire repository lock: /tmp/forbidden.lock"
+    );
+
+    expect(openMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("honors cancellation while waiting for lock", async () => {
+    openMock.mockRejectedValue(createErrnoError("EEXIST", "already locked"));
+
+    const shouldAbort = vi
+      .fn<() => boolean>()
+      .mockReturnValueOnce(false)
+      .mockReturnValue(true);
+
+    const lockPromise = acquireRepoLock("/tmp/cancel.lock", shouldAbort);
+    const rejectionExpectation = expect(lockPromise).rejects.toThrow(
+      "Job cancelled by user"
+    );
+
+    await vi.advanceTimersByTimeAsync(200);
+
+    await rejectionExpectation;
+    expect(openMock).toHaveBeenCalledTimes(1);
+    expect(rmMock).not.toHaveBeenCalled();
+  });
+});

--- a/scripts/api-server/job-executor.ts
+++ b/scripts/api-server/job-executor.ts
@@ -4,7 +4,8 @@
  */
 
 import { spawn, ChildProcess } from "node:child_process";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { JobType, GitHubContext } from "./job-tracker";
 import { getJobTracker } from "./job-tracker";
 import { createJobLogger } from "./job-persistence";
@@ -116,6 +117,12 @@ const SIGKILL_FAILSAFE_MS = 1000;
  * Maximum allowed timeout override (2 hours) in milliseconds
  */
 const MAX_TIMEOUT_MS = 2 * 60 * 60 * 1000; // 2 hours max
+
+const PROJECT_ROOT = resolve(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  ".."
+);
 
 /**
  * Parse and validate JOB_TIMEOUT_MS environment variable override.
@@ -290,7 +297,7 @@ export async function executeJob(
   const runJobProcess = async (cwd?: string): Promise<string> => {
     const processArgs = [...args];
     if (cwd && processArgs[0]?.startsWith("scripts/")) {
-      processArgs[0] = resolve(process.cwd(), processArgs[0]);
+      processArgs[0] = resolve(PROJECT_ROOT, processArgs[0]);
     }
 
     childProcess = spawn(jobConfig.script, processArgs, {


### PR DESCRIPTION
### Motivation
- The PR review for #129 flagged that the content-repo lock loop retried on all errors and hid real filesystem failures, causing long hangs. 
- The review also noted cancellation was not honored while waiting for the lock, allowing cancelled jobs to consume worker capacity. 
- Script path resolution relied on `process.cwd()` which makes content-managed job execution brittle if the service starts from a different working directory. 

### Description
- Changed `acquireRepoLock` in `scripts/api-server/content-repo.ts` to be exported, accept an optional `shouldAbort` callback, call `assertNotAborted` in each loop iteration, and only retry when the caught error has `code === 'EEXIST'`, rethrowing non-contention errors with contextual details. 
- Updated `runContentTask` to pass `options.shouldAbort` into `acquireRepoLock` so cancellation is respected while waiting for the lock and no lock file is leaked on abort. 
- Made script argument resolution in `scripts/api-server/job-executor.ts` independent of startup cwd by adding a module-derived `PROJECT_ROOT` and resolving `scripts/...` args against it instead of `process.cwd()`. 
- Added focused unit tests at `scripts/api-server/content-repo.test.ts` covering retry-on-`EEXIST`, fast-fail for non-`EEXIST` errors, and cancellation while waiting for a lock, and applied formatting/lint fixes to affected files. 

### Testing
- Ran formatting and linting with `bunx prettier --write <files>` and `bunx eslint <files> --fix` which completed successfully. 
- Executed the new unit tests with `bunx vitest run scripts/api-server/content-repo.test.ts` which passed. 
- Re-ran the related executor suite with `bunx vitest run scripts/api-server/job-executor-timeout.test.ts` which also passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698dbfaf274083278bd328ca5b8df080)

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Hardened content repository lock acquisition and script path resolution by addressing three high-priority reliability issues from PR #129 review.

**Key changes:**
- Modified `acquireRepoLock` to only retry on `EEXIST` (lock contention), failing fast on other filesystem errors like `EACCES`
- Added cancellation support to lock acquisition loop via optional `shouldAbort` callback, preventing cancelled jobs from waiting up to 30 minutes
- Replaced `process.cwd()` with module-derived `PROJECT_ROOT` for script path resolution, making execution independent of service startup directory
- Added comprehensive unit tests covering retry-on-contention, fast-fail for non-contention errors, and cancellation-while-waiting scenarios

The changes directly implement the P1 and P2 findings from the review document, improving both operational reliability and cancellation responsiveness.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes directly address documented review findings with proper error handling, comprehensive test coverage, and no breaking changes to existing APIs. The implementation follows defensive programming patterns (fail-fast on unexpected errors, explicit cancellation checks) and includes unit tests that validate all three core behaviors (retry, fast-fail, cancellation).
- No files require special attention

<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| scripts/api-server/content-repo.ts | Hardened lock acquisition with proper error handling, retry logic, and cancellation support |
| scripts/api-server/job-executor.ts | Fixed script path resolution to use module-derived PROJECT_ROOT instead of process.cwd() |
| scripts/api-server/content-repo.test.ts | Added comprehensive unit tests for lock retry, fast-fail, and cancellation scenarios |

</details>


</details>


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Job as Job Executor
    participant Repo as Content Repo
    participant Lock as Lock Acquisition
    participant FS as File System

    Job->>Repo: runContentTask(taskName, requestId, taskRunner, {shouldAbort})
    Repo->>Lock: acquireRepoLock(lockPath, shouldAbort)
    
    loop Lock Retry Loop
        Lock->>Lock: assertNotAborted(shouldAbort)
        alt Job Cancelled
            Lock-->>Repo: throw "Job cancelled by user"
            Repo-->>Job: ContentRepoError
        end
        
        Lock->>FS: open(lockPath, "wx")
        alt Lock Available
            FS-->>Lock: lockFile handle
            Lock-->>Repo: {release: fn}
        else EEXIST (Contention)
            FS-->>Lock: EEXIST error
            Lock->>Lock: wait 200ms and retry
        else Other Error (EACCES, etc)
            FS-->>Lock: error with code
            Lock-->>Repo: throw ContentRepoError with context
            Repo-->>Job: Error propagated
        end
    end
    
    Repo->>Repo: initializeContentRepo()
    Repo->>Repo: git operations (fetch, checkout, reset)
    Repo->>Job: taskRunner(workdir) with PROJECT_ROOT-resolved scripts
    Job->>Job: spawn(script, args, {cwd: workdir})
    Job-->>Repo: output
    Repo->>Repo: git commit and push
    Repo->>Lock: lock.release()
    Lock->>FS: close() and rm(lockPath)
    Repo-->>Job: {output, noOp, commitSha}
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->