### PR TITLE
fix(translate): use translated title for toggle section _category_.json

### DIFF
--- a/scripts/notion-translate/index.test.ts
+++ b/scripts/notion-translate/index.test.ts
@@ -1372,12 +1372,14 @@ describe("notion-translate index", () => {
       const filePath1 = await saveTranslatedContentToDisk(
         mockPage,
         "# Test Content",
+        "Test Page",
         mockConfig
       );
 
       const filePath2 = await saveTranslatedContentToDisk(
         mockPage,
         "# Test Content",
+        "Test Page",
         mockConfig
       );
 

--- a/scripts/notion-translate/index.ts
+++ b/scripts/notion-translate/index.ts
@@ -654,6 +654,7 @@ function isNotionImageUrlFamily(url: string): boolean {
 export async function saveTranslatedContentToDisk(
   englishPage: NotionPage,
   translatedContent: string,
+  translatedTitle: string,
   config: TranslationConfig
 ): Promise<string> {
   try {
@@ -681,7 +682,7 @@ export async function saveTranslatedContentToDisk(
 
         // Create _category_.json file
         const categoryContent = {
-          label: title,
+          label: translatedTitle,
           position:
             (
               englishPage.properties[NOTION_PROPERTIES.ORDER] as
@@ -694,7 +695,7 @@ export async function saveTranslatedContentToDisk(
             type: "generated-index",
           },
           customProps: {
-            title: title,
+            title: translatedTitle,
           },
         };
 
@@ -1217,7 +1218,12 @@ async function processSinglePageTranslation({
   );
 
   // Save translated content to output directory
-  await saveTranslatedContentToDisk(englishPage, translatedContent, config);
+  await saveTranslatedContentToDisk(
+    englishPage,
+    translatedContent,
+    translatedTitle,
+    config
+  );
 
   // Update statistics
   if (translationPage) {


### PR DESCRIPTION
## Scope

Partial fix for #157.

This PR is intentionally narrow so it can be reviewed, tested, and merged quickly. It only changes translated toggle `_category_.json` generation. End-to-end validation and any fallback/regression hardening are tracked separately in #158 and #159.

## Problem

Toggle sections were using the English source title in translated `_category_.json` output. That can make translated sidebar/category labels appear in English even when translated content exists.

## What This PR Changes

- uses `translatedTitle` for translated toggle `_category_.json` generation
- updates the code path that writes `label` and `customProps.title` for toggle section category metadata
- updates the targeted unit tests for this generation logic

## What This PR Does Not Claim To Finish

- end-to-end validation with real Notion content
- docs UI verification in translated locales
- fallback behavior hardening if translated titles are missing
- broader regression hardening beyond the targeted unit tests

## Review Focus

Review this PR as a narrow generator fix:
- does the generator use the translated title in the translated toggle `_category_.json` output?
- are the targeted tests aligned with that exact behavior?
- is the change isolated enough to merge quickly?

## Targeted Testing

- `bunx vitest run scripts/notion-translate/index.test.ts`
- inspect generated translated `_category_.json` for the affected toggle path if additional confidence is needed

## Related

- Umbrella bug: #157
- Follow-up verification: #158
- Follow-up hardening: #159