### PR TITLE
feat(translate): add no-overwrite strategy for human-reviewed translations

### DIFF
--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -191,6 +191,7 @@ jobs:
           export PROCESSED_LANGS="0"
           export NEW_TRANSLATIONS="0"
           export UPDATED_TRANSLATIONS="0"
+          export AUTOMATED_TRANSLATIONS="0"
           export SKIPPED_TRANSLATIONS="0"
           export FAILED_TRANSLATIONS="0"
           export CODE_JSON_FAILURES="0"
@@ -205,6 +206,7 @@ jobs:
             PROCESSED_LANGS=$(jq -r '.processedLanguages // 0' translation-summary.json)
             NEW_TRANSLATIONS=$(jq -r '.newTranslations // 0' translation-summary.json)
             UPDATED_TRANSLATIONS=$(jq -r '.updatedTranslations // 0' translation-summary.json)
+            AUTOMATED_TRANSLATIONS=$(jq -r '.automatedTranslations // 0' translation-summary.json)
             SKIPPED_TRANSLATIONS=$(jq -r '.skippedTranslations // 0' translation-summary.json)
             FAILED_TRANSLATIONS=$(jq -r '.failedTranslations // 0' translation-summary.json)
             CODE_JSON_FAILURES=$(jq -r '.codeJsonFailures // 0' translation-summary.json)
@@ -230,6 +232,7 @@ jobs:
               PROCESSED_LANGS=$(echo "$JSON_PART" | jq -r '.processedLanguages // "0"' 2>/dev/null || echo "0")
               NEW_TRANSLATIONS=$(echo "$JSON_PART" | jq -r '.newTranslations // "0"' 2>/dev/null || echo "0")
               UPDATED_TRANSLATIONS=$(echo "$JSON_PART" | jq -r '.updatedTranslations // "0"' 2>/dev/null || echo "0")
+              AUTOMATED_TRANSLATIONS=$(echo "$JSON_PART" | jq -r '.automatedTranslations // "0"' 2>/dev/null || echo "0")
               SKIPPED_TRANSLATIONS=$(echo "$JSON_PART" | jq -r '.skippedTranslations // "0"' 2>/dev/null || echo "0")
               FAILED_TRANSLATIONS=$(echo "$JSON_PART" | jq -r '.failedTranslations // "0"' 2>/dev/null || echo "0")
               CODE_JSON_FAILURES=$(echo "$JSON_PART" | jq -r '.codeJsonFailures // "0"' 2>/dev/null || echo "0")
@@ -249,6 +252,7 @@ jobs:
             echo "processed_langs=$PROCESSED_LANGS"
             echo "new_translations=$NEW_TRANSLATIONS"
             echo "updated_translations=$UPDATED_TRANSLATIONS"
+            echo "automated_translations=$AUTOMATED_TRANSLATIONS"
             echo "skipped_translations=$SKIPPED_TRANSLATIONS"
             echo "failed_translations=$FAILED_TRANSLATIONS"
             echo "code_json_failures=$CODE_JSON_FAILURES"
@@ -262,6 +266,7 @@ jobs:
           echo "  Processed languages: $PROCESSED_LANGS"
           echo "  New translations: $NEW_TRANSLATIONS"
           echo "  Updated translations: $UPDATED_TRANSLATIONS"
+          echo "  Automated translations: $AUTOMATED_TRANSLATIONS"
           echo "  Skipped translations: $SKIPPED_TRANSLATIONS"
           echo "  Failed translations: $FAILED_TRANSLATIONS"
           echo "  Code.json failures: $CODE_JSON_FAILURES"
@@ -269,7 +274,7 @@ jobs:
           echo "  Has failures: $HAS_FAILURES"
 
       - name: Update Notion Status → Auto Translation Generated
-        if: success() && (steps.parse_summary.outputs.new_translations != '0' || steps.parse_summary.outputs.updated_translations != '0')
+        if: success() && (steps.parse_summary.outputs.new_translations != '0' || steps.parse_summary.outputs.updated_translations != '0' || steps.parse_summary.outputs.automated_translations != '0')
         run: |
           # Use test database if test mode is enabled
           if [ -n "${{ secrets.TEST_DATA_SOURCE_ID }}" ] || [ -n "${{ secrets.TEST_DATABASE_ID }}" ] || [ "${{ secrets.TEST_MODE }}" = "true" ]; then

--- a/.gitignore
+++ b/.gitignore
@@ -113,3 +113,6 @@ telemetry-id
 *.log
 *.skill
 api-server/flaky-test-counts.txt
+
+# Automated translation output (never commit generated translations)
+automated-translations/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -158,3 +158,13 @@ See `context/workflows/PRODUCTION_DEPLOYMENT.md` for complete workflow.
 - Architecture & Lessons: `./NOTION_FETCH_ARCHITECTURE.md`
 - Workflows: `./context/workflows/` (commands, lifecycle, translations, production deployment)
 - Quick Lookups: `./context/quick-ref/` (mappings, status, examples)
+
+## Approach
+- Think before acting. Read existing files before writing code.
+- Be concise in output but thorough in reasoning.
+- Prefer editing over rewriting whole files.
+- Do not re-read files you have already read unless the file may have changed.
+- Test your code before declaring done.
+- No sycophantic openers or closing fluff.
+- Keep solutions simple and direct.
+- User instructions always override this file.

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "notion:export": "bun scripts/notion-fetch/exportDatabase.ts",
     "notion:gen-placeholders": "bun scripts/notion-placeholders",
     "notion:fetch-all": "bun scripts/notion-fetch-all",
+    "notion:push-translation": "bun scripts/push-new-translation-to-notion.ts",
+    "notion:translate-test": "bun scripts/run-single-page-translation.ts",
     "api:server": "bun api-server",
     "api:server:dev": "bun --watch api-server",
     "clean:generated": "bun scripts/cleanup-generated-content.ts",

--- a/scripts/constants.test.ts
+++ b/scripts/constants.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import {
   MAIN_LANGUAGE,
   NOTION_PROPERTIES,
@@ -22,6 +22,14 @@ import {
   getTestDatabaseId,
   isSafeTestBranch,
   getModelParams,
+  getModelContextLimit,
+  getMaxChunkChars,
+  AUTOMATED_OUTPUT_DIRS,
+  AUTOMATED_LANGUAGE_MAP,
+  isAutomatedLanguageCode,
+  getBaseLanguageCode,
+  getAutomatedLanguageCode,
+  getAutomatedOutputDir,
   type TranslationConfig,
   type NotionPage,
 } from "./constants";
@@ -48,13 +56,11 @@ describe("constants", () => {
     it("should have correct max retries value", () => {
       // Arrange & Act & Assert
       expect(MAX_RETRIES).toBe(3);
-      expect(typeof MAX_RETRIES).toBe("number");
     });
 
     it("should have correct Notion API chunk size", () => {
       // Arrange & Act & Assert
       expect(NOTION_API_CHUNK_SIZE).toBe(50);
-      expect(typeof NOTION_API_CHUNK_SIZE).toBe("number");
     });
   });
 
@@ -89,7 +95,8 @@ describe("constants", () => {
   describe("LANGUAGES configuration", () => {
     it("should contain Portuguese and Spanish configurations", () => {
       // Arrange & Act & Assert
-      expect(LANGUAGES).toHaveLength(2);
+      // Use >= 2 so adding more languages in future doesn't break this test
+      expect(LANGUAGES.length).toBeGreaterThanOrEqual(2);
 
       const portuguese = LANGUAGES.find((lang) => lang.language === "pt-BR");
       const spanish = LANGUAGES.find((lang) => lang.language === "es");
@@ -151,41 +158,25 @@ describe("constants", () => {
       expect(PNG_QUALITY_RANGE[1]).toBe(0.8);
       expect(PNG_QUALITY_RANGE[0]).toBeLessThan(PNG_QUALITY_RANGE[1]);
     });
-
-    it("should have reasonable image processing values", () => {
-      // Arrange & Act & Assert
-      expect(IMAGE_MAX_WIDTH).toBeGreaterThan(0);
-      expect(JPEG_QUALITY).toBeGreaterThan(0);
-      expect(JPEG_QUALITY).toBeLessThanOrEqual(100);
-      expect(PNG_COMPRESSION_LEVEL).toBeGreaterThanOrEqual(0);
-      expect(PNG_COMPRESSION_LEVEL).toBeLessThanOrEqual(9);
-      expect(WEBP_QUALITY).toBeGreaterThan(0);
-      expect(WEBP_QUALITY).toBeLessThanOrEqual(100);
-    });
   });
 
   describe("OpenAI constants", () => {
-    it("should use environment variable for model when available", () => {
-      // Test that the constant exists - actual env var testing is complex in ES modules
+    // NOTE: DEFAULT_OPENAI_MODEL is a top-level const resolved at import time
+    // (process.env.OPENAI_MODEL || "gpt-5-mini"). Its value cannot be changed
+    // by modifying process.env after the module is loaded; env-var override
+    // tests would be false positives. Test the constant's value/format only.
+    it("should have a valid model name string", () => {
       expect(DEFAULT_OPENAI_MODEL).toBeDefined();
       expect(typeof DEFAULT_OPENAI_MODEL).toBe("string");
       expect(DEFAULT_OPENAI_MODEL.length).toBeGreaterThan(0);
-    });
-
-    it("should use default model when environment variable is not set", () => {
-      // Test that we have a reasonable default
-      expect(DEFAULT_OPENAI_MODEL).toBeDefined();
-      expect(typeof DEFAULT_OPENAI_MODEL).toBe("string");
-      // Should be a valid OpenAI model name format
-      expect(DEFAULT_OPENAI_MODEL).toMatch(/gpt|claude/i);
+      // Should be a valid model name format
+      expect(DEFAULT_OPENAI_MODEL).toMatch(/gpt|claude|deepseek/i);
     });
 
     it("should have correct default OpenAI values", () => {
       // Arrange & Act & Assert
       expect(DEFAULT_OPENAI_TEMPERATURE).toBe(0.3);
       expect(DEFAULT_OPENAI_MAX_TOKENS).toBe(4096);
-      expect(typeof DEFAULT_OPENAI_TEMPERATURE).toBe("number");
-      expect(typeof DEFAULT_OPENAI_MAX_TOKENS).toBe("number");
     });
 
     it("should have reasonable OpenAI parameter ranges", () => {
@@ -223,253 +214,341 @@ describe("constants", () => {
           reasoning_effort: "none",
         });
       });
+
+      it("should return DEFAULT_OPENAI_TEMPERATURE for gpt-5.2 without useReasoningNone", () => {
+        // gpt-5.2 without the reasoning flag falls through to the default temperature path
+        expect(getModelParams("gpt-5.2")).toEqual({
+          temperature: DEFAULT_OPENAI_TEMPERATURE,
+        });
+      });
+
+      it("should be case-insensitive for model names", () => {
+        // Arrange & Act & Assert
+        expect(getModelParams("GPT-5-NANO")).toEqual({ temperature: 1 });
+        expect(getModelParams("gpt-5")).toEqual({ temperature: 1 });
+        expect(getModelParams(" gpt-5-nano ")).toEqual({ temperature: 1 });
+        expect(getModelParams("gpt-5-nano")).toEqual({ temperature: 1 });
+      });
+
+      it("should handle GPT-5 variants correctly", () => {
+        // Arrange & Act & Assert - ensure exact match and prefix match work
+        expect(getModelParams("gpt-5")).toEqual({ temperature: 1 });
+        expect(getModelParams("gpt-5-nano")).toEqual({ temperature: 1 });
+        expect(getModelParams("gpt-5-mini")).toEqual({ temperature: 1 });
+        // GPT-5-chat-latest may support temperature with reasoning_effort=none
+        expect(getModelParams("gpt-5-chat-latest")).toEqual({ temperature: 1 });
+      });
     });
-    it("should be case-insensitive for model names", () => {
+  });
+
+  describe("getModelContextLimit", () => {
+    it("should return correct token limit for an exact model key", () => {
+      // gpt-4o is a known entry with 128000 tokens
+      expect(getModelContextLimit("gpt-4o")).toBe(128000);
+    });
+
+    it("should return the same limit for a versioned variant via prefix match", () => {
+      // "gpt-5-mini-2025-01-01" starts with "gpt-5-mini" which maps to 272000
+      expect(getModelContextLimit("gpt-5-mini-2025-01-01")).toBe(272000);
+    });
+
+    it("should return the conservative default (128000) for unknown models", () => {
+      expect(getModelContextLimit("unknown-model-xyz")).toBe(128000);
+    });
+
+    it("should normalize case and whitespace before matching", () => {
+      expect(getModelContextLimit("  GPT-4O  ")).toBe(128000);
+      expect(getModelContextLimit("GPT-5-MINI")).toBe(272000);
+    });
+  });
+
+  describe("getMaxChunkChars", () => {
+    it("should return floor((contextLimit * 3.5) / 1.5) for a known model", () => {
+      // gpt-4o has contextLimit = 128000
+      // expected = floor(128000 * 3.5 / 1.5) = floor(298666.66...) = 298666
+      const expected = Math.floor((128000 * 3.5) / 1.5);
+      expect(getMaxChunkChars("gpt-4o")).toBe(expected);
+    });
+
+    it("should apply formula correctly for a high-context model", () => {
+      // gpt-5-mini has contextLimit = 272000
+      const expected = Math.floor((272000 * 3.5) / 1.5);
+      expect(getMaxChunkChars("gpt-5-mini")).toBe(expected);
+    });
+  });
+
+  describe("automated language helpers", () => {
+    it("AUTOMATED_OUTPUT_DIRS has entries for pt-BR and es", () => {
+      expect(AUTOMATED_OUTPUT_DIRS).toHaveProperty("pt-BR");
+      expect(AUTOMATED_OUTPUT_DIRS).toHaveProperty("es");
+      expect(typeof AUTOMATED_OUTPUT_DIRS["pt-BR"]).toBe("string");
+      expect(typeof AUTOMATED_OUTPUT_DIRS["es"]).toBe("string");
+    });
+
+    it("AUTOMATED_LANGUAGE_MAP maps Portuguese and Spanish to automated codes", () => {
+      expect(AUTOMATED_LANGUAGE_MAP["Portuguese"]).toBe("PT - automated");
+      expect(AUTOMATED_LANGUAGE_MAP["Spanish"]).toBe("ES - automated");
+    });
+
+    describe("isAutomatedLanguageCode", () => {
+      it("returns true for a known automated code", () => {
+        expect(isAutomatedLanguageCode("PT - automated")).toBe(true);
+      });
+
+      it("returns false for a base language name", () => {
+        expect(isAutomatedLanguageCode("Portuguese")).toBe(false);
+      });
+    });
+
+    describe("getBaseLanguageCode", () => {
+      it("returns the base language name for a known automated code", () => {
+        expect(getBaseLanguageCode("PT - automated")).toBe("Portuguese");
+      });
+
+      it("passes through an unknown code unchanged", () => {
+        expect(getBaseLanguageCode("French")).toBe("French");
+      });
+    });
+
+    describe("getAutomatedLanguageCode", () => {
+      it("returns the automated code for a known base language", () => {
+        expect(getAutomatedLanguageCode("Portuguese")).toBe("PT - automated");
+      });
+
+      it("passes through a code that is already automated", () => {
+        expect(getAutomatedLanguageCode("PT - automated")).toBe(
+          "PT - automated"
+        );
+      });
+
+      it("returns a fallback template string for an unknown language", () => {
+        expect(getAutomatedLanguageCode("French")).toBe("French-automated");
+      });
+    });
+
+    describe("getAutomatedOutputDir", () => {
+      it("returns the expected path for pt-BR", () => {
+        expect(getAutomatedOutputDir("pt-BR")).toBe(
+          "./automated-translations/pt"
+        );
+      });
+
+      it("returns undefined for an unsupported locale", () => {
+        expect(getAutomatedOutputDir("fr")).toBeUndefined();
+      });
+    });
+  });
+
+  describe("safety messages", () => {
+    it("should have correct English modification error message", () => {
       // Arrange & Act & Assert
-      expect(getModelParams("GPT-5-NANO")).toEqual({ temperature: 1 });
-      expect(getModelParams("gpt-5")).toEqual({ temperature: 1 });
-      expect(getModelParams(" gpt-5-nano ")).toEqual({ temperature: 1 });
-      expect(getModelParams("gpt-5-nano")).toEqual({ temperature: 1 });
+      expect(ENGLISH_MODIFICATION_ERROR).toBe(
+        "SAFETY ERROR: Cannot create or update English pages. This is a critical safety measure to prevent data loss."
+      );
+      expect(typeof ENGLISH_MODIFICATION_ERROR).toBe("string");
     });
 
-    it("should handle GPT-5 variants correctly", () => {
-      // Arrange & Act & Assert - ensure exact match and prefix match work
-      expect(getModelParams("gpt-5")).toEqual({ temperature: 1 });
-      expect(getModelParams("gpt-5-nano")).toEqual({ temperature: 1 });
-      expect(getModelParams("gpt-5-mini")).toEqual({ temperature: 1 });
-      // GPT-5-chat-latest may support temperature with reasoning_effort=none
-      expect(getModelParams("gpt-5-chat-latest")).toEqual({ temperature: 1 });
+    it("should have correct English directory save error message", () => {
+      // Arrange & Act & Assert
+      expect(ENGLISH_DIR_SAVE_ERROR).toBe(
+        "Safety check failed: Cannot save translated content to English docs directory"
+      );
+      expect(typeof ENGLISH_DIR_SAVE_ERROR).toBe("string");
     });
   });
-});
 
-describe("safety messages", () => {
-  it("should have correct English modification error message", () => {
-    // Arrange & Act & Assert
-    expect(ENGLISH_MODIFICATION_ERROR).toBe(
-      "SAFETY ERROR: Cannot create or update English pages. This is a critical safety measure to prevent data loss."
-    );
-    expect(typeof ENGLISH_MODIFICATION_ERROR).toBe("string");
-  });
-
-  it("should have correct English directory save error message", () => {
-    // Arrange & Act & Assert
-    expect(ENGLISH_DIR_SAVE_ERROR).toBe(
-      "Safety check failed: Cannot save translated content to English docs directory"
-    );
-    expect(typeof ENGLISH_DIR_SAVE_ERROR).toBe("string");
-  });
-
-  it("should have non-empty safety messages", () => {
-    // Arrange & Act & Assert
-    expect(ENGLISH_MODIFICATION_ERROR.length).toBeGreaterThan(0);
-    expect(ENGLISH_DIR_SAVE_ERROR.length).toBeGreaterThan(0);
-  });
-});
-
-describe("TypeScript interfaces", () => {
-  it("should accept valid TranslationConfig objects", () => {
-    // Arrange
-    const validConfig: TranslationConfig = {
-      language: "fr",
-      notionLangCode: "French",
-      outputDir: "./i18n/fr/docs",
-    };
-
-    // Act & Assert
-    expect(validConfig.language).toBe("fr");
-    expect(validConfig.notionLangCode).toBe("French");
-    expect(validConfig.outputDir).toBe("./i18n/fr/docs");
-  });
-
-  it("should accept valid NotionPage objects", () => {
-    // Arrange
-    const validPage: NotionPage = {
-      id: "test-id",
-      last_edited_time: "2024-01-01T00:00:00.000Z",
-      properties: {
-        Title: { title: [{ plain_text: "Test" }] },
-      },
-      parent: { type: "database_id", database_id: "db-id" },
-    };
-
-    // Act & Assert
-    expect(validPage.id).toBe("test-id");
-    expect(validPage.last_edited_time).toBe("2024-01-01T00:00:00.000Z");
-    expect(validPage.properties).toBeDefined();
-    expect(typeof validPage.properties).toBe("object");
-  });
-});
-
-describe("test environment configuration", () => {
-  it("should have defined safe branch patterns", () => {
-    // Arrange & Act & Assert
-    expect(SAFE_BRANCH_PATTERNS).toBeDefined();
-    expect(Array.isArray(SAFE_BRANCH_PATTERNS)).toBe(true);
-    expect(SAFE_BRANCH_PATTERNS.length).toBeGreaterThan(0);
-  });
-
-  it("should include expected safe branch patterns", () => {
-    // Arrange & Act & Assert
-    expect(SAFE_BRANCH_PATTERNS).toContain("test/*");
-    expect(SAFE_BRANCH_PATTERNS).toContain("fix/*");
-    expect(SAFE_BRANCH_PATTERNS).toContain("feat/*");
-    expect(SAFE_BRANCH_PATTERNS).toContain("chore/*");
-    expect(SAFE_BRANCH_PATTERNS).toContain("refactor/*");
-  });
-
-  it("should have defined protected branches", () => {
-    // Arrange & Act & Assert
-    expect(PROTECTED_BRANCHES).toBeDefined();
-    expect(Array.isArray(PROTECTED_BRANCHES)).toBe(true);
-    expect(PROTECTED_BRANCHES.length).toBeGreaterThan(0);
-  });
-
-  it("should include expected protected branches", () => {
-    // Arrange & Act & Assert
-    expect(PROTECTED_BRANCHES).toContain("main");
-    expect(PROTECTED_BRANCHES).toContain("master");
-    expect(PROTECTED_BRANCHES).toContain("content");
-  });
-
-  describe("isTestMode", () => {
-    it("should return false when no test env vars are set", () => {
+  describe("TypeScript interfaces", () => {
+    it("should accept valid TranslationConfig objects", () => {
       // Arrange
-      delete process.env.TEST_MODE;
-      delete process.env.TEST_DATABASE_ID;
-      delete process.env.TEST_DATA_SOURCE_ID;
+      const validConfig: TranslationConfig = {
+        language: "fr",
+        notionLangCode: "French",
+        outputDir: "./i18n/fr/docs",
+      };
 
       // Act & Assert
-      expect(isTestMode()).toBe(false);
+      expect(validConfig.language).toBe("fr");
+      expect(validConfig.notionLangCode).toBe("French");
+      expect(validConfig.outputDir).toBe("./i18n/fr/docs");
     });
 
-    it("should return true when TEST_MODE is 'true'", () => {
+    it("should accept valid NotionPage objects", () => {
       // Arrange
-      process.env.TEST_MODE = "true";
-      delete process.env.TEST_DATABASE_ID;
-      delete process.env.TEST_DATA_SOURCE_ID;
+      const validPage: NotionPage = {
+        id: "test-id",
+        last_edited_time: "2024-01-01T00:00:00.000Z",
+        properties: {
+          Title: { title: [{ plain_text: "Test" }] },
+        },
+        parent: { type: "database_id", database_id: "db-id" },
+      };
 
       // Act & Assert
-      expect(isTestMode()).toBe(true);
-    });
-
-    it("should return true when TEST_DATABASE_ID is set", () => {
-      // Arrange
-      delete process.env.TEST_MODE;
-      process.env.TEST_DATABASE_ID = "test-db-id";
-      delete process.env.TEST_DATA_SOURCE_ID;
-
-      // Act & Assert
-      expect(isTestMode()).toBe(true);
-    });
-
-    it("should return true when TEST_DATA_SOURCE_ID is set", () => {
-      // Arrange
-      delete process.env.TEST_MODE;
-      delete process.env.TEST_DATABASE_ID;
-      process.env.TEST_DATA_SOURCE_ID = "test-data-source-id";
-
-      // Act & Assert
-      expect(isTestMode()).toBe(true);
+      expect(validPage.id).toBe("test-id");
+      expect(validPage.last_edited_time).toBe("2024-01-01T00:00:00.000Z");
+      expect(validPage.properties).toBeDefined();
+      expect(typeof validPage.properties).toBe("object");
     });
   });
 
-  describe("getTestDataSourceId", () => {
-    it("should return undefined when TEST_DATA_SOURCE_ID is not set", () => {
-      // Arrange
-      delete process.env.TEST_DATA_SOURCE_ID;
-
-      // Act & Assert
-      expect(getTestDataSourceId()).toBeUndefined();
+  describe("test environment configuration", () => {
+    it("should have defined safe branch patterns", () => {
+      // Arrange & Act & Assert
+      expect(SAFE_BRANCH_PATTERNS).toBeDefined();
+      expect(Array.isArray(SAFE_BRANCH_PATTERNS)).toBe(true);
+      expect(SAFE_BRANCH_PATTERNS.length).toBeGreaterThan(0);
     });
 
-    it("should return the value when TEST_DATA_SOURCE_ID is set", () => {
-      // Arrange
-      process.env.TEST_DATA_SOURCE_ID = "test-data-source-id";
-
-      // Act & Assert
-      expect(getTestDataSourceId()).toBe("test-data-source-id");
-    });
-  });
-
-  describe("getTestDatabaseId", () => {
-    it("should return undefined when TEST_DATABASE_ID is not set", () => {
-      // Arrange
-      delete process.env.TEST_DATABASE_ID;
-
-      // Act & Assert
-      expect(getTestDatabaseId()).toBeUndefined();
+    it("should include expected safe branch patterns", () => {
+      // Arrange & Act & Assert
+      expect(SAFE_BRANCH_PATTERNS).toContain("test/*");
+      expect(SAFE_BRANCH_PATTERNS).toContain("fix/*");
+      expect(SAFE_BRANCH_PATTERNS).toContain("feat/*");
+      expect(SAFE_BRANCH_PATTERNS).toContain("chore/*");
+      expect(SAFE_BRANCH_PATTERNS).toContain("refactor/*");
     });
 
-    it("should return the value when TEST_DATABASE_ID is set", () => {
-      // Arrange
-      process.env.TEST_DATABASE_ID = "test-db-id";
-
-      // Act & Assert
-      expect(getTestDatabaseId()).toBe("test-db-id");
-    });
-  });
-
-  describe("isSafeTestBranch", () => {
-    beforeEach(() => {
-      // Clear test mode env vars before each test
-      delete process.env.TEST_MODE;
-      delete process.env.TEST_DATABASE_ID;
-      delete process.env.TEST_DATA_SOURCE_ID;
+    it("should have defined protected branches", () => {
+      // Arrange & Act & Assert
+      expect(PROTECTED_BRANCHES).toBeDefined();
+      expect(Array.isArray(PROTECTED_BRANCHES)).toBe(true);
+      expect(PROTECTED_BRANCHES.length).toBeGreaterThan(0);
     });
 
-    it("should return true for any branch when not in test mode", () => {
-      // Arrange - ensure we're NOT in test mode
-      delete process.env.TEST_MODE;
-      delete process.env.TEST_DATABASE_ID;
-      delete process.env.TEST_DATA_SOURCE_ID;
-
-      // Act & Assert
-      expect(isSafeTestBranch("main")).toBe(true);
-      expect(isSafeTestBranch("content")).toBe(true);
-      expect(isSafeTestBranch("any-branch")).toBe(true);
+    it("should include expected protected branches", () => {
+      // Arrange & Act & Assert
+      expect(PROTECTED_BRANCHES).toContain("main");
+      expect(PROTECTED_BRANCHES).toContain("master");
+      expect(PROTECTED_BRANCHES).toContain("content");
     });
 
-    it("should return true for safe pattern branches in test mode", () => {
-      // Arrange - enable test mode
-      process.env.TEST_MODE = "true";
+    describe("isTestMode", () => {
+      it("should return false when no test env vars are set", () => {
+        // Arrange
+        delete process.env.TEST_MODE;
+        delete process.env.TEST_DATABASE_ID;
+        delete process.env.TEST_DATA_SOURCE_ID;
 
-      // Act & Assert
-      expect(isSafeTestBranch("test/translation")).toBe(true);
-      expect(isSafeTestBranch("fix/something")).toBe(true);
-      expect(isSafeTestBranch("feat/new-feature")).toBe(true);
-      expect(isSafeTestBranch("chore/update")).toBe(true);
-      expect(isSafeTestBranch("refactor/cleanup")).toBe(true);
+        // Act & Assert
+        expect(isTestMode()).toBe(false);
+      });
+
+      it("should return true when TEST_MODE is 'true'", () => {
+        // Arrange
+        process.env.TEST_MODE = "true";
+        delete process.env.TEST_DATABASE_ID;
+        delete process.env.TEST_DATA_SOURCE_ID;
+
+        // Act & Assert
+        expect(isTestMode()).toBe(true);
+      });
+
+      it("should return true when TEST_DATABASE_ID is set", () => {
+        // Arrange
+        delete process.env.TEST_MODE;
+        process.env.TEST_DATABASE_ID = "test-db-id";
+        delete process.env.TEST_DATA_SOURCE_ID;
+
+        // Act & Assert
+        expect(isTestMode()).toBe(true);
+      });
+
+      it("should return true when TEST_DATA_SOURCE_ID is set", () => {
+        // Arrange
+        delete process.env.TEST_MODE;
+        delete process.env.TEST_DATABASE_ID;
+        process.env.TEST_DATA_SOURCE_ID = "test-data-source-id";
+
+        // Act & Assert
+        expect(isTestMode()).toBe(true);
+      });
     });
 
-    it("should return true for branches with 'test' in name in test mode", () => {
-      // Arrange - enable test mode
-      process.env.TEST_MODE = "true";
+    describe("getTestDataSourceId", () => {
+      it("should return undefined when TEST_DATA_SOURCE_ID is not set", () => {
+        // Arrange
+        delete process.env.TEST_DATA_SOURCE_ID;
 
-      // Act & Assert
-      expect(isSafeTestBranch("my-test-branch")).toBe(true);
-      expect(isSafeTestBranch("test-translation-fix")).toBe(true);
-      expect(isSafeTestBranch("testing-123")).toBe(true);
+        // Act & Assert
+        expect(getTestDataSourceId()).toBeUndefined();
+      });
+
+      it("should return the value when TEST_DATA_SOURCE_ID is set", () => {
+        // Arrange
+        process.env.TEST_DATA_SOURCE_ID = "test-data-source-id";
+
+        // Act & Assert
+        expect(getTestDataSourceId()).toBe("test-data-source-id");
+      });
     });
 
-    it("should return false for protected branches in test mode", () => {
-      // Arrange - enable test mode
-      process.env.TEST_MODE = "true";
+    describe("getTestDatabaseId", () => {
+      it("should return undefined when TEST_DATABASE_ID is not set", () => {
+        // Arrange
+        delete process.env.TEST_DATABASE_ID;
 
-      // Act & Assert
-      expect(isSafeTestBranch("main")).toBe(false);
-      expect(isSafeTestBranch("master")).toBe(false);
-      expect(isSafeTestBranch("content")).toBe(false);
+        // Act & Assert
+        expect(getTestDatabaseId()).toBeUndefined();
+      });
+
+      it("should return the value when TEST_DATABASE_ID is set", () => {
+        // Arrange
+        process.env.TEST_DATABASE_ID = "test-db-id";
+
+        // Act & Assert
+        expect(getTestDatabaseId()).toBe("test-db-id");
+      });
     });
 
-    it("should return false for non-safe, non-test branches in test mode", () => {
-      // Arrange - enable test mode
-      process.env.TEST_MODE = "true";
+    describe("isSafeTestBranch", () => {
+      it("should return true for any branch when not in test mode", () => {
+        // Act & Assert
+        expect(isSafeTestBranch("main")).toBe(true);
+        expect(isSafeTestBranch("content")).toBe(true);
+        expect(isSafeTestBranch("any-branch")).toBe(true);
+      });
 
-      // Act & Assert
-      expect(isSafeTestBranch("production")).toBe(false);
-      expect(isSafeTestBranch("staging")).toBe(false);
-      expect(isSafeTestBranch("develop")).toBe(false);
+      it("should return true for safe pattern branches in test mode", () => {
+        // Arrange - enable test mode
+        process.env.TEST_MODE = "true";
+
+        // Act & Assert
+        expect(isSafeTestBranch("test/translation")).toBe(true);
+        expect(isSafeTestBranch("fix/something")).toBe(true);
+        expect(isSafeTestBranch("feat/new-feature")).toBe(true);
+        expect(isSafeTestBranch("chore/update")).toBe(true);
+        expect(isSafeTestBranch("refactor/cleanup")).toBe(true);
+      });
+
+      it("should return true for branches with 'test' in name in test mode", () => {
+        // Arrange - enable test mode
+        process.env.TEST_MODE = "true";
+
+        // Act & Assert
+        expect(isSafeTestBranch("my-test-branch")).toBe(true);
+        expect(isSafeTestBranch("test-translation-fix")).toBe(true);
+        expect(isSafeTestBranch("testing-123")).toBe(true);
+      });
+
+      it("should return false for protected branches in test mode", () => {
+        // Arrange - enable test mode
+        process.env.TEST_MODE = "true";
+
+        // Act & Assert
+        expect(isSafeTestBranch("main")).toBe(false);
+        expect(isSafeTestBranch("master")).toBe(false);
+        expect(isSafeTestBranch("content")).toBe(false);
+      });
+
+      it("should return false for non-safe, non-test branches in test mode", () => {
+        // Arrange - enable test mode
+        process.env.TEST_MODE = "true";
+
+        // Act & Assert
+        expect(isSafeTestBranch("production")).toBe(false);
+        expect(isSafeTestBranch("staging")).toBe(false);
+        expect(isSafeTestBranch("develop")).toBe(false);
+      });
     });
   });
 });

--- a/scripts/constants.ts
+++ b/scripts/constants.ts
@@ -55,6 +55,39 @@ export const LANGUAGES: TranslationConfig[] = [
   },
 ];
 
+export const AUTOMATED_OUTPUT_DIRS: Record<string, string> = {
+  "pt-BR": "./automated-translations/pt",
+  es: "./automated-translations/es",
+};
+
+/** Maps base Notion language names to their automated select option values. */
+export const AUTOMATED_LANGUAGE_MAP: Record<string, string> = {
+  Portuguese: "PT - automated",
+  Spanish: "ES - automated",
+};
+
+export function isAutomatedLanguageCode(code: string): boolean {
+  return Object.values(AUTOMATED_LANGUAGE_MAP).includes(code);
+}
+
+export function getBaseLanguageCode(code: string): string {
+  for (const [base, automated] of Object.entries(AUTOMATED_LANGUAGE_MAP)) {
+    if (automated === code) return base;
+  }
+  return code;
+}
+
+export function getAutomatedLanguageCode(code: string): string {
+  if (isAutomatedLanguageCode(code)) return code; // already automated
+  // eslint-disable-next-line security/detect-object-injection -- code is a known language name from the AUTOMATED_LANGUAGE_MAP keys
+  return AUTOMATED_LANGUAGE_MAP[code] ?? `${code}-automated`;
+}
+
+export function getAutomatedOutputDir(language: string): string | undefined {
+  // eslint-disable-next-line security/detect-object-injection -- language is validated against known locale keys from AUTOMATED_OUTPUT_DIRS
+  return AUTOMATED_OUTPUT_DIRS[language];
+}
+
 // Maximum number of retries for API calls
 export const MAX_RETRIES = 3;
 

--- a/scripts/fetchNotionData.ts
+++ b/scripts/fetchNotionData.ts
@@ -33,7 +33,7 @@ export async function fetchNotionData(filter) {
 
     // Use DATA_SOURCE_ID with fallback to DATABASE_ID
     // Note: notionClient.ts will warn if DATA_SOURCE_ID is not set
-    const dataSourceId = DATA_SOURCE_ID || DATABASE_ID;
+    const dataSourceId = (DATA_SOURCE_ID || DATABASE_ID) as string;
 
     const response = await enhancedNotion.dataSourcesQuery({
       // v5 API: data_source_id parameter

--- a/scripts/fetchNotionData.ts
+++ b/scripts/fetchNotionData.ts
@@ -336,9 +336,15 @@ export async function sortAndExpandNotionData(
 // const pageId = '16d8004e5f6a42a6981151c22ddada12';
 // await fetchNotionPage(pageId);
 export async function fetchNotionPage() {
+  const blockId = DATABASE_ID ?? DATA_SOURCE_ID;
+  if (!blockId) {
+    throw new Error(
+      "Neither DATABASE_ID nor DATA_SOURCE_ID is set. Cannot fetch Notion page blocks."
+    );
+  }
   try {
     const response = await enhancedNotion.blocksChildrenList({
-      block_id: DATABASE_ID,
+      block_id: blockId,
     });
     console.log("Fetched page content:", response);
     return response;

--- a/scripts/notion-fetch/generateBlocks.ts
+++ b/scripts/notion-fetch/generateBlocks.ts
@@ -132,6 +132,8 @@ const LANGUAGE_NAME_TO_LOCALE: Record<string, string> = {
   English: "en",
   Spanish: "es",
   Portuguese: "pt",
+  "PT - automated": "pt",
+  "ES - automated": "es",
 };
 
 const FALLBACK_TITLE_PREFIX = "untitled";

--- a/scripts/notion-fetch/pageGrouping.ts
+++ b/scripts/notion-fetch/pageGrouping.ts
@@ -16,11 +16,28 @@ const LANGUAGE_NAME_TO_LOCALE: Record<string, string> = {
   es: "es",
   pt: "pt",
 };
+
+/** Language names that represent machine-generated (automated) translations. */
+const AUTOMATED_LANGUAGE_NAMES = new Set(["pt - automated", "es - automated"]);
+
 const LOCALE_PRIORITY = new Map(
   config.i18n.locales.map((locale, index) => [locale, index])
 );
 
-type LocaleResolutionSource = "explicit" | "fallback";
+/**
+ * Priority order (highest wins): explicit > automated > fallback
+ * - "explicit"  – human-reviewed translation with a named locale
+ * - "automated" – machine-generated translation (lower priority than explicit)
+ * - "fallback"  – locale inferred from default, no language property
+ */
+type LocaleResolutionSource = "explicit" | "automated" | "fallback";
+
+/** Numeric rank for each source — higher value wins when two pages claim the same locale. */
+const SOURCE_RANK: Record<LocaleResolutionSource, number> = {
+  fallback: 0,
+  automated: 1,
+  explicit: 2,
+};
 
 type LocaleResolution = {
   locale: string;
@@ -168,7 +185,9 @@ const resolvePageLocaleDetails = (
   ) {
     return {
       locale: LANGUAGE_NAME_TO_LOCALE[normalizedLanguageName],
-      source: "explicit",
+      source: AUTOMATED_LANGUAGE_NAMES.has(normalizedLanguageName)
+        ? "automated"
+        : "explicit",
     };
   }
 
@@ -209,9 +228,12 @@ export const groupPagesByLang = (
   const upsertLocalizedContent = (candidatePage: Record<string, any>) => {
     const resolution = resolvePageLocaleDetails(candidatePage);
     const existingSource = localeSources[resolution.locale];
+    // A slot is only replaced when the incoming source strictly outranks the
+    // existing one, so human-reviewed ("explicit") pages always win over
+    // machine-generated ("automated") ones regardless of Sub-item order.
     const shouldReplace =
       existingSource === undefined ||
-      (existingSource === "fallback" && resolution.source === "explicit");
+      SOURCE_RANK[resolution.source] > SOURCE_RANK[existingSource];
 
     if (shouldReplace) {
       grouped.content[resolution.locale] = candidatePage;

--- a/scripts/notion-fetch/pageGrouping.ts
+++ b/scripts/notion-fetch/pageGrouping.ts
@@ -10,6 +10,8 @@ const LANGUAGE_NAME_TO_LOCALE: Record<string, string> = {
   english: "en",
   spanish: "es",
   portuguese: "pt",
+  "pt - automated": "pt",
+  "es - automated": "es",
   en: "en",
   es: "es",
   pt: "pt",

--- a/scripts/notion-translate/__tests__/no-overwrite.live.test.ts
+++ b/scripts/notion-translate/__tests__/no-overwrite.live.test.ts
@@ -1,0 +1,315 @@
+/**
+ * Live Notion API integration test for the no-overwrite translation strategy (Issue #171).
+ *
+ * Purpose: Verify that createNotionPageWithBlocks() with forceCreate=true always
+ * creates a new page and never deduplicates or overwrites existing translations.
+ *
+ * These tests make real Notion API calls. They are skipped unless ALL of the
+ * following are true:
+ *   - RUN_LIVE_NOTION_TESTS=1
+ *   - NOTION_API_KEY is set
+ *   - DATA_SOURCE_ID or DATABASE_ID is set
+ *
+ * Run manually with:
+ *   RUN_LIVE_NOTION_TESTS=1 bunx vitest run scripts/notion-translate/__tests__/no-overwrite.live.test.ts
+ *
+ * Created pages are archived after each test unless NO_OVERWRITE_KEEP_PAGE=1.
+ */
+
+import { readFileSync } from "fs";
+import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { Client } from "@notionhq/client";
+
+// ---------------------------------------------------------------------------
+// Env loading — MUST come before any imports that transitively load notionClient
+// ---------------------------------------------------------------------------
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const envPath = resolve(__dirname, "../../../.env");
+
+try {
+  const raw = readFileSync(envPath, "utf-8");
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith("#")) continue;
+    const eq = trimmed.indexOf("=");
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const val = trimmed
+      .slice(eq + 1)
+      .trim()
+      .replace(/^["']|["']$/g, "");
+    // Always overwrite these keys from .env so that the global Vitest setup
+    // (vitest.setup.ts), which pre-populates fake values, does not shadow the
+    // real credentials we need for live API calls.
+    if (key === "NOTION_API_KEY") {
+      process.env.NOTION_API_KEY = val;
+    }
+    if (key === "DATABASE_ID") {
+      process.env.DATABASE_ID = val;
+    }
+    if (key === "DATA_SOURCE_ID") {
+      process.env.DATA_SOURCE_ID = val;
+    }
+  }
+} catch {
+  // .env not present — rely on environment variables already set
+}
+
+// ---------------------------------------------------------------------------
+// Guard — skip entire suite unless live credentials are present and opted-in
+// ---------------------------------------------------------------------------
+
+const shouldRun =
+  process.env.RUN_LIVE_NOTION_TESTS === "1" &&
+  !!process.env.NOTION_API_KEY &&
+  !!(process.env.DATA_SOURCE_ID || process.env.DATABASE_ID);
+
+// ---------------------------------------------------------------------------
+// Types (inline to avoid importing from production modules at the top level)
+// ---------------------------------------------------------------------------
+
+type NotionPage = {
+  id: string;
+  archived: boolean;
+  properties: Record<string, unknown>;
+};
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+describe.skipIf(!shouldRun)(
+  "no-overwrite live Notion API — forceCreate=true always creates new pages",
+  { timeout: 60_000 },
+  () => {
+    // Lazily-imported production modules (populated in beforeAll)
+    type TranslateBlocksModule = typeof import("../translateBlocks.js");
+    type NotionClientModule = typeof import("../../notionClient.js");
+
+    // A fresh Notion client with a 30s timeout so live API calls don't hit
+    // the 5s test-environment timeout baked into the shared notionClient export.
+    let liveNotion: Client;
+    let DATA_SOURCE_ID: string;
+    let DATABASE_ID: string;
+    let createNotionPageWithBlocks: TranslateBlocksModule["createNotionPageWithBlocks"];
+
+    let parentPageId: string;
+    let createdPageId: string | null = null;
+    let secondCreatedPageId: string | null = null;
+
+    const keepPage = process.env.NO_OVERWRITE_KEEP_PAGE === "1";
+
+    // -----------------------------------------------------------------------
+    // Setup
+    // -----------------------------------------------------------------------
+
+    beforeAll(async () => {
+      // Create a fresh Notion client with a 30s timeout. We do NOT reuse the
+      // shared `notion` export from notionClient.ts because under Vitest that
+      // client is built with IS_TEST_ENV=true and a 5s timeout, which is too
+      // short for live API calls.
+      liveNotion = new Client({
+        auth: process.env.NOTION_API_KEY!,
+        timeoutMs: 30_000,
+        notionVersion: "2025-09-03",
+      });
+
+      // Also import DATA_SOURCE_ID / DATABASE_ID from the shared module so we
+      // target the correct database — dynamic import ensures env vars are read.
+      const notionClientModule = (await import(
+        "../../notionClient.js"
+      )) as NotionClientModule;
+      DATA_SOURCE_ID = notionClientModule.DATA_SOURCE_ID;
+      DATABASE_ID = notionClientModule.DATABASE_ID;
+
+      const translateBlocksModule = await import("../translateBlocks.js");
+      createNotionPageWithBlocks =
+        translateBlocksModule.createNotionPageWithBlocks;
+
+      // Retrieve a known stable English page to use as parent reference.
+      const fallbackId = "2331b08162d58090ab6ad6c1c5f60dda";
+      const englishPage = (await liveNotion.pages.retrieve({
+        page_id: fallbackId,
+      })) as NotionPage;
+
+      // Extract parent page ID from the "Parent item" relation, falling back to
+      // the page's own ID so the test page is at least linked somewhere valid.
+      const parentItemProp = englishPage.properties["Parent item"] as
+        | { relation?: { id: string }[] }
+        | undefined;
+      parentPageId = parentItemProp?.relation?.[0]?.id ?? englishPage.id;
+
+      const titleProp = englishPage.properties["Content elements"] as
+        | { title?: { plain_text?: string }[] }
+        | undefined;
+      const pageTitle = titleProp?.title?.[0]?.plain_text ?? "(unknown title)";
+
+      console.log(
+        `[live-test] Using English page id=${englishPage.id} title="${pageTitle}" as parent reference`
+      );
+    }, 60_000);
+
+    // -----------------------------------------------------------------------
+    // Cleanup
+    // -----------------------------------------------------------------------
+
+    afterEach(async () => {
+      const idsToArchive: (string | null)[] = [
+        createdPageId,
+        secondCreatedPageId,
+      ];
+
+      for (const pageId of idsToArchive) {
+        if (!pageId) continue;
+
+        if (keepPage) {
+          const url = `https://notion.so/${pageId.replace(/-/g, "")}`;
+          console.log(`[live-test] Keeping page for inspection: ${url}`);
+        } else {
+          try {
+            await liveNotion.pages.update({ page_id: pageId, archived: true });
+          } catch (err) {
+            console.warn(
+              `[live-test] Failed to archive page ${pageId}:`,
+              err instanceof Error ? err.message : String(err)
+            );
+          }
+        }
+      }
+
+      createdPageId = null;
+      secondCreatedPageId = null;
+    }, 30_000);
+
+    // -----------------------------------------------------------------------
+    // Test 1 — forceCreate=true creates a new page with Language = "PT - automated"
+    // -----------------------------------------------------------------------
+
+    it('creates a new automated page with Language = "PT - automated" via forceCreate=true', async () => {
+      const databaseId = DATA_SOURCE_ID || DATABASE_ID;
+      const title = `[LIVE-TEST] No-Overwrite ${new Date().toISOString().slice(0, 19)}`;
+
+      const blocks = [
+        {
+          object: "block" as const,
+          type: "paragraph" as const,
+          paragraph: {
+            rich_text: [
+              {
+                type: "text" as const,
+                text: { content: "[LIVE-TEST] automated content" },
+              },
+            ],
+          },
+        },
+      ];
+
+      const properties = {
+        Language: { select: { name: "PT - automated" } },
+      };
+
+      createdPageId = await createNotionPageWithBlocks(
+        liveNotion,
+        parentPageId,
+        databaseId,
+        title,
+        blocks,
+        properties,
+        "PT - automated",
+        undefined, // existingPageId — always create new
+        true // forceCreate
+      );
+
+      expect(createdPageId).toBeTruthy();
+      expect(typeof createdPageId).toBe("string");
+
+      const notionUrl = `https://notion.so/${createdPageId.replace(/-/g, "")}`;
+      console.log(`[live-test] Created page: ${notionUrl}`);
+
+      // Retrieve the page and assert its properties
+      const page = (await liveNotion.pages.retrieve({
+        page_id: createdPageId,
+      })) as NotionPage;
+
+      expect(page.archived).toBe(false);
+
+      const langProp = page.properties["Language"] as
+        | { select?: { name?: string } }
+        | undefined;
+      expect(langProp?.select?.name).toBe("PT - automated");
+
+      const titleProp = page.properties["Content elements"] as
+        | { title?: { plain_text?: string }[] }
+        | undefined;
+      const retrievedTitle =
+        titleProp?.title?.map((t) => t.plain_text ?? "").join("") ?? "";
+      expect(retrievedTitle).toBe(title);
+    });
+
+    // -----------------------------------------------------------------------
+    // Test 2 — two calls with forceCreate=true produce two distinct page IDs
+    // -----------------------------------------------------------------------
+
+    it("two calls with forceCreate=true produce two distinct pages (no dedup)", async () => {
+      const databaseId = DATA_SOURCE_ID || DATABASE_ID;
+      const sharedTitle = `[LIVE-TEST] Dedup-check ${new Date().toISOString().slice(0, 19)}`;
+
+      const blocks = [
+        {
+          object: "block" as const,
+          type: "paragraph" as const,
+          paragraph: {
+            rich_text: [
+              {
+                type: "text" as const,
+                text: { content: "[LIVE-TEST] automated content" },
+              },
+            ],
+          },
+        },
+      ];
+
+      const properties = {
+        Language: { select: { name: "PT - automated" } },
+      };
+
+      createdPageId = await createNotionPageWithBlocks(
+        liveNotion,
+        parentPageId,
+        databaseId,
+        sharedTitle,
+        blocks,
+        properties,
+        "PT - automated",
+        undefined,
+        true
+      );
+
+      secondCreatedPageId = await createNotionPageWithBlocks(
+        liveNotion,
+        parentPageId,
+        databaseId,
+        sharedTitle,
+        blocks,
+        properties,
+        "PT - automated",
+        undefined,
+        true
+      );
+
+      expect(createdPageId).toBeTruthy();
+      expect(secondCreatedPageId).toBeTruthy();
+      expect(createdPageId).not.toBe(secondCreatedPageId);
+
+      console.log(
+        `[live-test] First page:  https://notion.so/${createdPageId!.replace(/-/g, "")}`
+      );
+      console.log(
+        `[live-test] Second page: https://notion.so/${secondCreatedPageId!.replace(/-/g, "")}`
+      );
+    });
+  }
+);

--- a/scripts/notion-translate/__tests__/no-overwrite.test.ts
+++ b/scripts/notion-translate/__tests__/no-overwrite.test.ts
@@ -870,7 +870,7 @@ describe("no-overwrite translation routing (Issue #171)", () => {
     expect(mockNotionPagesCreate).not.toHaveBeenCalled();
   });
 
-  it("Scenario 11: missing DATABASE_ID logs warning and continues automated processing", async () => {
+  it("Scenario 11: DATA_SOURCE_ID-only workflow validates via data source and continues automated processing", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     const englishPage = createMockNotionPage({
@@ -920,8 +920,9 @@ describe("no-overwrite translation routing (Issue #171)", () => {
     expect(summary.skippedTranslations).toBe(1);
     expect(mockNotionDatabasesRetrieve).not.toHaveBeenCalled();
     expect(mockNotionPagesCreate).toHaveBeenCalledTimes(1);
-    expect(warnSpy).toHaveBeenCalledWith(
-      "Cannot verify automated language select options without DATABASE_ID — ensure they exist in Notion"
+    // Validation warning must NOT fire when DATA_SOURCE_ID is present
+    expect(warnSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("Cannot verify automated language select options")
     );
 
     warnSpy.mockRestore();

--- a/scripts/notion-translate/__tests__/no-overwrite.test.ts
+++ b/scripts/notion-translate/__tests__/no-overwrite.test.ts
@@ -989,32 +989,32 @@ describe("no-overwrite translation routing (Issue #171)", () => {
 
   it("Scenario 12: successful automated option validation → automated processing continues", async () => {
     const englishPage = createMockNotionPage({
-      id: "en-page-sc11",
+      id: "en-page-sc12",
       title: "Automated Success Page",
       status: "Ready for translation",
       language: "English",
       order: 1,
-      parentItem: "parent-11",
+      parentItem: "parent-12",
       elementType: "Page",
       lastEdited: "2026-02-01T00:00:00.000Z",
     });
     const ptTranslation = createMockNotionPage({
-      id: "pt-page-sc11",
+      id: "pt-page-sc12",
       title: "Página de Sucesso",
       status: "Auto Translation Generated",
       language: "Portuguese",
       order: 1,
-      parentItem: "parent-11",
+      parentItem: "parent-12",
       elementType: "Page",
       lastEdited: "2026-01-01T00:00:00.000Z",
     });
     const esTranslation = createMockNotionPage({
-      id: "es-page-sc11",
+      id: "es-page-sc12",
       title: "Página de Éxito",
       status: "Auto Translation Generated",
       language: "Spanish",
       order: 1,
-      parentItem: "parent-11",
+      parentItem: "parent-12",
       elementType: "Page",
       lastEdited: "2026-03-01T00:00:00.000Z",
     });
@@ -1037,32 +1037,32 @@ describe("no-overwrite translation routing (Issue #171)", () => {
 
   it("Scenario 13: automated language validation runs once per process", async () => {
     const englishPage = createMockNotionPage({
-      id: "en-page-sc12",
+      id: "en-page-sc13",
       title: "Automated Cache Page",
       status: "Ready for translation",
       language: "English",
       order: 1,
-      parentItem: "parent-12",
+      parentItem: "parent-13",
       elementType: "Page",
       lastEdited: "2026-02-01T00:00:00.000Z",
     });
     const ptTranslation = createMockNotionPage({
-      id: "pt-page-sc12",
+      id: "pt-page-sc13",
       title: "Página Cache PT",
       status: "Auto Translation Generated",
       language: "Portuguese",
       order: 1,
-      parentItem: "parent-12",
+      parentItem: "parent-13",
       elementType: "Page",
       lastEdited: "2026-01-01T00:00:00.000Z",
     });
     const esTranslation = createMockNotionPage({
-      id: "es-page-sc12",
+      id: "es-page-sc13",
       title: "Página Cache ES",
       status: "Auto Translation Generated",
       language: "Spanish",
       order: 1,
-      parentItem: "parent-12",
+      parentItem: "parent-13",
       elementType: "Page",
       lastEdited: "2026-01-01T00:00:00.000Z",
     });

--- a/scripts/notion-translate/__tests__/no-overwrite.test.ts
+++ b/scripts/notion-translate/__tests__/no-overwrite.test.ts
@@ -28,6 +28,7 @@ const mockBlocksChildrenList = vi.fn();
 const mockPagesRetrieve = vi.fn();
 const mockResolveCanonicalDocsRelativePath = vi.fn();
 const mockNotionDataSourcesQuery = vi.fn();
+const mockNotionDataSourcesRetrieve = vi.fn();
 const mockNotionDatabasesRetrieve = vi.fn();
 const mockNotionPagesCreate = vi.fn();
 const mockNotionPagesUpdate = vi.fn();
@@ -61,7 +62,10 @@ vi.mock("fs/promises", () => ({
 
 vi.mock("../../notionClient", () => ({
   notion: {
-    dataSources: { query: mockNotionDataSourcesQuery },
+    dataSources: {
+      query: mockNotionDataSourcesQuery,
+      retrieve: mockNotionDataSourcesRetrieve,
+    },
     databases: { retrieve: mockNotionDatabasesRetrieve },
     pages: { create: mockNotionPagesCreate, update: mockNotionPagesUpdate },
     blocks: {
@@ -178,6 +182,14 @@ function setupCommonMocks(
     results: [],
     has_more: false,
   });
+  mockNotionDataSourcesRetrieve.mockResolvedValue(
+    createLanguageSchemaResponse([
+      "Portuguese",
+      "Spanish",
+      "PT - automated",
+      "ES - automated",
+    ])
+  );
   mockNotionDatabasesRetrieve.mockResolvedValue(
     createLanguageSchemaResponse([
       "Portuguese",
@@ -268,6 +280,14 @@ function setupThreeLevelMocks(
     results: [],
     has_more: false,
   });
+  mockNotionDataSourcesRetrieve.mockResolvedValue(
+    createLanguageSchemaResponse([
+      "Portuguese",
+      "Spanish",
+      "PT - automated",
+      "ES - automated",
+    ])
+  );
   mockNotionDatabasesRetrieve.mockResolvedValue(
     createLanguageSchemaResponse([
       "Portuguese",
@@ -320,6 +340,7 @@ describe("no-overwrite translation routing (Issue #171)", () => {
     mockDataSourceId = defaultMockDataSourceId;
     // Re-wire mocks after reset
     mockGetRequestScheduler.mockReturnValue({ destroy: mockSchedulerDestroy });
+    mockNotionDataSourcesRetrieve.mockReset();
   });
 
   afterEach(() => {
@@ -832,6 +853,9 @@ describe("no-overwrite translation routing (Issue #171)", () => {
       Portuguese: ptTranslation,
       Spanish: esTranslation,
     });
+    mockNotionDataSourcesRetrieve.mockResolvedValue(
+      createLanguageSchemaResponse(["Portuguese", "Spanish"])
+    );
     mockNotionDatabasesRetrieve.mockResolvedValue(
       createLanguageSchemaResponse(["Portuguese", "Spanish"])
     );
@@ -841,7 +865,8 @@ describe("no-overwrite translation routing (Issue #171)", () => {
       "Translation workflow completed with failures (docs: 1, code.json: 0, theme: 0)"
     );
 
-    expect(mockNotionDatabasesRetrieve).toHaveBeenCalledTimes(1);
+    expect(mockNotionDataSourcesRetrieve).toHaveBeenCalledTimes(1);
+    expect(mockNotionDatabasesRetrieve).not.toHaveBeenCalled();
     expect(mockNotionPagesCreate).not.toHaveBeenCalled();
   });
 
@@ -902,6 +927,65 @@ describe("no-overwrite translation routing (Issue #171)", () => {
     warnSpy.mockRestore();
   });
 
+  it("Scenario 11a: validates against the active data source when DATABASE_ID differs", async () => {
+    const englishPage = createMockNotionPage({
+      id: "en-page-sc11a",
+      title: "Active Source Validation Page",
+      status: "Ready for translation",
+      language: "English",
+      order: 1,
+      parentItem: "parent-11a",
+      elementType: "Page",
+      lastEdited: "2026-02-01T00:00:00.000Z",
+    });
+    const ptTranslation = createMockNotionPage({
+      id: "pt-page-sc11a",
+      title: "Página de Origem Ativa",
+      status: "Auto Translation Generated",
+      language: "Portuguese",
+      order: 1,
+      parentItem: "parent-11a",
+      elementType: "Page",
+      lastEdited: "2026-01-01T00:00:00.000Z",
+    });
+    const esTranslation = createMockNotionPage({
+      id: "es-page-sc11a",
+      title: "Página de Origem Ativa ES",
+      status: "Auto Translation Generated",
+      language: "Spanish",
+      order: 1,
+      parentItem: "parent-11a",
+      elementType: "Page",
+      lastEdited: "2026-03-01T00:00:00.000Z",
+    });
+
+    setupCommonMocks(englishPage, {
+      Portuguese: ptTranslation,
+      Spanish: esTranslation,
+    });
+    mockNotionDatabasesRetrieve.mockResolvedValue(
+      createLanguageSchemaResponse([])
+    );
+    mockNotionDataSourcesRetrieve.mockResolvedValue(
+      createLanguageSchemaResponse([
+        "Portuguese",
+        "Spanish",
+        "PT - automated",
+        "ES - automated",
+      ])
+    );
+
+    const { main } = await import("../index.js");
+    const summary = await main({});
+
+    expect(summary.automatedTranslations).toBe(1);
+    expect(summary.failedTranslations).toBe(0);
+    expect(summary.skippedTranslations).toBe(1);
+    expect(mockNotionDataSourcesRetrieve).toHaveBeenCalledTimes(1);
+    expect(mockNotionDatabasesRetrieve).not.toHaveBeenCalled();
+    expect(mockNotionPagesCreate).toHaveBeenCalledTimes(1);
+  });
+
   it("Scenario 12: successful automated option validation → automated processing continues", async () => {
     const englishPage = createMockNotionPage({
       id: "en-page-sc11",
@@ -945,7 +1029,8 @@ describe("no-overwrite translation routing (Issue #171)", () => {
     expect(summary.automatedTranslations).toBe(1);
     expect(summary.failedTranslations).toBe(0);
     expect(summary.skippedTranslations).toBe(1);
-    expect(mockNotionDatabasesRetrieve).toHaveBeenCalledTimes(1);
+    expect(mockNotionDataSourcesRetrieve).toHaveBeenCalledTimes(1);
+    expect(mockNotionDatabasesRetrieve).not.toHaveBeenCalled();
     expect(mockNotionPagesCreate).toHaveBeenCalledTimes(1);
   });
 
@@ -991,7 +1076,8 @@ describe("no-overwrite translation routing (Issue #171)", () => {
 
     expect(summary.automatedTranslations).toBe(2);
     expect(summary.failedTranslations).toBe(0);
-    expect(mockNotionDatabasesRetrieve).toHaveBeenCalledTimes(1);
+    expect(mockNotionDataSourcesRetrieve).toHaveBeenCalledTimes(1);
+    expect(mockNotionDatabasesRetrieve).not.toHaveBeenCalled();
     expect(mockNotionPagesCreate).toHaveBeenCalledTimes(2);
   });
 

--- a/scripts/notion-translate/__tests__/no-overwrite.test.ts
+++ b/scripts/notion-translate/__tests__/no-overwrite.test.ts
@@ -1,0 +1,514 @@
+/**
+ * Integration tests for the no-overwrite translation strategy (Issue #171).
+ *
+ * Tests the routing logic in processLanguageTranslations() that determines
+ * whether to use the automated path (when an existing translation is found)
+ * or the normal new-translation path.
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createMockNotionPage, installTestNotionEnv } from "../../test-utils";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before any imports that trigger module resolution
+// ---------------------------------------------------------------------------
+
+const mockFetchNotionData = vi.fn();
+const mockSortAndExpandNotionData = vi.fn();
+const mockTranslateText = vi.fn();
+const mockTranslateJson = vi.fn();
+const mockExtractTranslatableText = vi.fn();
+const mockGetLanguageName = vi.fn();
+const mockReadFile = vi.fn();
+const mockWriteFile = vi.fn();
+const mockMkdir = vi.fn();
+const mockAccess = vi.fn();
+const mockReaddir = vi.fn();
+const mockStat = vi.fn();
+const mockBlocksChildrenList = vi.fn();
+const mockPagesRetrieve = vi.fn();
+const mockResolveCanonicalDocsRelativePath = vi.fn();
+const mockNotionDataSourcesQuery = vi.fn();
+const mockNotionPagesCreate = vi.fn();
+const mockNotionPagesUpdate = vi.fn();
+const mockNotionBlocksChildrenList = vi.fn();
+const mockNotionBlocksChildrenAppend = vi.fn();
+const mockNotionBlocksDelete = vi.fn();
+const mockSchedulerDestroy = vi.fn();
+const mockGetRequestScheduler = vi.fn(() => ({
+  destroy: mockSchedulerDestroy,
+}));
+
+const mockN2m = {
+  pageToMarkdown: vi.fn(),
+  toMarkdownString: vi.fn(),
+};
+
+vi.mock("fs/promises", () => ({
+  default: {
+    readFile: mockReadFile,
+    writeFile: mockWriteFile,
+    mkdir: mockMkdir,
+    access: mockAccess,
+    readdir: mockReaddir,
+    stat: mockStat,
+  },
+}));
+
+vi.mock("../../notionClient", () => ({
+  notion: {
+    dataSources: { query: mockNotionDataSourcesQuery },
+    pages: { create: mockNotionPagesCreate, update: mockNotionPagesUpdate },
+    blocks: {
+      children: {
+        list: mockNotionBlocksChildrenList,
+        append: mockNotionBlocksChildrenAppend,
+      },
+      delete: mockNotionBlocksDelete,
+    },
+  },
+  DATABASE_ID: "test-database-id",
+  DATA_SOURCE_ID: "test-data-source-id",
+  n2m: mockN2m,
+  enhancedNotion: {
+    dataSourcesQuery: mockNotionDataSourcesQuery,
+    blocksChildrenList: mockBlocksChildrenList,
+    pagesRetrieve: mockPagesRetrieve,
+  },
+}));
+
+vi.mock("../../fetchNotionData.js", () => ({
+  fetchNotionData: mockFetchNotionData,
+  sortAndExpandNotionData: mockSortAndExpandNotionData,
+}));
+
+vi.mock("../../notion-fetch/requestScheduler", () => ({
+  getRequestScheduler: mockGetRequestScheduler,
+}));
+
+vi.mock("../../notion-fetch/pageMetadataCache.js", () => ({
+  resolveCanonicalDocsRelativePath: mockResolveCanonicalDocsRelativePath,
+}));
+
+vi.mock("../translateFrontMatter", () => ({
+  translateText: mockTranslateText,
+  TranslationError: class TranslationError extends Error {
+    isCritical = true;
+  },
+}));
+
+vi.mock("../translateCodeJson", () => ({
+  translateJson: mockTranslateJson,
+  extractTranslatableText: mockExtractTranslatableText,
+  getLanguageName: mockGetLanguageName,
+}));
+
+// ---------------------------------------------------------------------------
+// Helper: set up common mock defaults for a given English page
+// ---------------------------------------------------------------------------
+
+type FilterCondition = {
+  property?: string;
+  select?: { equals?: string };
+  relation?: { contains?: string };
+};
+
+function setupCommonMocks(
+  englishPage: ReturnType<typeof createMockNotionPage>,
+  translationsByLanguage: Record<
+    string,
+    ReturnType<typeof createMockNotionPage>
+  > = {}
+) {
+  mockFetchNotionData.mockImplementation(async (filter: unknown) => {
+    const f = filter as { and?: FilterCondition[] };
+    // English page fetch (Publish Status filter)
+    if (f?.and?.some((c) => c.property === "Publish Status") || !f?.and) {
+      return [englishPage];
+    }
+    // Translation lookup (Parent item + Language)
+    const langCondition = f?.and?.find((c) => c.property === "Language");
+    if (langCondition?.select?.equals) {
+      const lang = langCondition.select.equals;
+      return translationsByLanguage[lang] ? [translationsByLanguage[lang]] : [];
+    }
+    return [];
+  });
+  mockSortAndExpandNotionData.mockImplementation(
+    async (pages: unknown[]) => pages
+  );
+  mockN2m.pageToMarkdown.mockResolvedValue([]);
+  mockN2m.toMarkdownString.mockReturnValue({
+    parent: "# Translated\n\nContent",
+  });
+  mockBlocksChildrenList.mockResolvedValue({
+    results: [
+      {
+        type: "heading_1",
+        has_children: false,
+        heading_1: { rich_text: [{ plain_text: "Translated content" }] },
+      },
+    ],
+    has_more: false,
+    next_cursor: null,
+  });
+  mockNotionDataSourcesQuery.mockResolvedValue({
+    results: [],
+    has_more: false,
+  });
+  mockNotionPagesCreate.mockResolvedValue({ id: "new-page-id" });
+  mockNotionPagesUpdate.mockResolvedValue({});
+  mockNotionBlocksChildrenList.mockResolvedValue({
+    results: [],
+    has_more: false,
+  });
+  mockNotionBlocksChildrenAppend.mockResolvedValue({});
+  mockNotionBlocksDelete.mockResolvedValue({});
+  mockTranslateText.mockResolvedValue({
+    markdown: "# Traduzido",
+    title: "Traduzido",
+  });
+  mockTranslateJson.mockResolvedValue("{}");
+  mockExtractTranslatableText.mockReturnValue({});
+  mockGetLanguageName.mockImplementation((lang: string) =>
+    lang === "pt" ? "Portuguese" : "Spanish"
+  );
+  mockResolveCanonicalDocsRelativePath.mockImplementation((pageId: string) =>
+    pageId === englishPage.id ? "test-page.md" : null
+  );
+  // Default: i18n file does NOT exist
+  mockAccess.mockRejectedValue(new Error("ENOENT"));
+  mockReadFile.mockResolvedValue("");
+  mockWriteFile.mockResolvedValue(undefined);
+  mockMkdir.mockResolvedValue(undefined);
+  // translateThemeConfig needs readdir to return an iterable
+  mockReaddir.mockResolvedValue([]);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("no-overwrite translation routing (Issue #171)", () => {
+  let restoreEnv: () => void;
+
+  beforeEach(() => {
+    restoreEnv = installTestNotionEnv();
+    vi.resetAllMocks();
+    // Re-wire mocks after reset
+    mockGetRequestScheduler.mockReturnValue({ destroy: mockSchedulerDestroy });
+  });
+
+  afterEach(() => {
+    restoreEnv();
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario 1: No existing translation → normal new-translation path
+  // -------------------------------------------------------------------------
+  it("Scenario 1: no existing translation → creates new translation normally", async () => {
+    const englishPage = createMockNotionPage({
+      id: "en-page-sc1",
+      title: "Test Page",
+      status: "Ready for translation",
+      language: "English",
+      order: 1,
+      parentItem: "parent-1",
+      elementType: "Page",
+      lastEdited: "2026-02-01T00:00:00.000Z",
+    });
+
+    setupCommonMocks(englishPage);
+    // No Portuguese or Spanish translations returned
+    mockNotionDataSourcesQuery.mockResolvedValue({
+      results: [],
+      has_more: false,
+    });
+
+    const { main } = await import("../index.js");
+    const summary = await main({});
+
+    // Both languages create new pages — no automated path
+    expect(summary.automatedTranslations).toBe(0);
+    expect(summary.newTranslations).toBe(2); // pt-BR + es
+    expect(summary.failedTranslations).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario 2: Existing translation, translation is NEWER → skips
+  // -------------------------------------------------------------------------
+  it("Scenario 2: existing translation is newer than English → skips (no update)", async () => {
+    const englishPage = createMockNotionPage({
+      id: "en-page-sc2",
+      title: "Test Page",
+      status: "Ready for translation",
+      language: "English",
+      order: 1,
+      parentItem: "parent-2",
+      elementType: "Page",
+      lastEdited: "2026-01-01T00:00:00.000Z", // English is OLDER
+    });
+    const ptTranslation = createMockNotionPage({
+      id: "pt-page-sc2",
+      title: "Página de Teste",
+      status: "Auto Translation Generated",
+      language: "Portuguese",
+      order: 1,
+      parentItem: "parent-2",
+      elementType: "Page",
+      lastEdited: "2026-02-01T00:00:00.000Z", // Translation is NEWER
+    });
+    const esTranslation = createMockNotionPage({
+      id: "es-page-sc2",
+      title: "Página de Prueba",
+      status: "Auto Translation Generated",
+      language: "Spanish",
+      order: 1,
+      parentItem: "parent-2",
+      elementType: "Page",
+      lastEdited: "2026-02-01T00:00:00.000Z",
+    });
+
+    setupCommonMocks(englishPage, {
+      Portuguese: ptTranslation,
+      Spanish: esTranslation,
+    });
+    // Translation blocks exist with content → needsTranslationUpdate returns needsUpdate=false
+
+    const { main } = await import("../index.js");
+    const summary = await main({});
+
+    expect(summary.skippedTranslations).toBe(2); // both languages skipped
+    expect(summary.automatedTranslations).toBe(0);
+    expect(summary.newTranslations).toBe(0);
+    expect(summary.updatedTranslations).toBe(0);
+    expect(mockNotionPagesCreate).not.toHaveBeenCalled();
+    expect(mockNotionPagesUpdate).not.toHaveBeenCalled();
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario 3: Existing translation, English IS newer → automated path
+  // -------------------------------------------------------------------------
+  it("Scenario 3: existing translation, English is newer → automated path (new page, not update)", async () => {
+    const englishPage = createMockNotionPage({
+      id: "en-page-sc3",
+      title: "Test Page",
+      status: "Ready for translation",
+      language: "English",
+      order: 1,
+      parentItem: "parent-3",
+      elementType: "Page",
+      lastEdited: "2026-02-01T00:00:00.000Z", // English is NEWER
+    });
+    const ptTranslation = createMockNotionPage({
+      id: "pt-page-sc3",
+      title: "Página de Teste",
+      status: "Auto Translation Generated",
+      language: "Portuguese",
+      order: 1,
+      parentItem: "parent-3",
+      elementType: "Page",
+      lastEdited: "2026-01-01T00:00:00.000Z", // Translation is OLDER
+    });
+
+    setupCommonMocks(englishPage, { Portuguese: ptTranslation });
+
+    const { main } = await import("../index.js");
+    const summary = await main({});
+
+    // Portuguese → automated path (English newer, existing translation exists)
+    // Spanish → normal new translation path (no existing translation)
+    expect(summary.automatedTranslations).toBe(1);
+    expect(summary.newTranslations).toBe(1); // Spanish
+    expect(summary.updatedTranslations).toBe(0); // No updates
+    expect(summary.failedTranslations).toBe(0);
+
+    // Automated path always creates (forceCreate) — never updates
+    expect(mockNotionPagesCreate).toHaveBeenCalledTimes(2); // 1 automated PT + 1 new ES
+    expect(mockNotionPagesUpdate).toHaveBeenCalledTimes(0);
+
+    // Disk write called for the automated translation
+    expect(mockWriteFile).toHaveBeenCalled();
+    const writeCalls = mockWriteFile.mock.calls.map(
+      ([p]: [string]) => p as string
+    );
+    const automatedWrite = writeCalls.some((p) =>
+      p.includes("automated-translations")
+    );
+    expect(automatedWrite).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario 4: localOnly + existing i18n file → automated path, no Notion calls
+  // -------------------------------------------------------------------------
+  it("Scenario 4: localOnly mode with existing i18n file → automated path, no Notion calls", async () => {
+    const englishPage = createMockNotionPage({
+      id: "en-page-sc4",
+      title: "Test Page",
+      status: "Ready for translation",
+      language: "English",
+      order: 1,
+      parentItem: "parent-4",
+      elementType: "Page",
+      lastEdited: "2026-02-01T00:00:00.000Z",
+    });
+
+    setupCommonMocks(englishPage);
+    // In localOnly mode, no Notion queries for translations
+    // But we simulate an existing i18n file on disk
+    mockAccess.mockResolvedValue(undefined); // i18n file EXISTS
+
+    const { main } = await import("../index.js");
+    const summary = await main({ localOnly: true });
+
+    expect(summary.automatedTranslations).toBe(2); // Both PT and ES routes automated
+    expect(summary.newTranslations).toBe(0);
+    expect(summary.failedTranslations).toBe(0);
+
+    // localOnly → no Notion API calls
+    expect(mockNotionPagesCreate).not.toHaveBeenCalled();
+    expect(mockNotionPagesUpdate).not.toHaveBeenCalled();
+
+    // Disk write to automated-translations/ directory
+    const writeCalls = mockWriteFile.mock.calls.map(
+      ([p]: [string]) => p as string
+    );
+    const automatedWrite = writeCalls.some((p) =>
+      p.includes("automated-translations")
+    );
+    expect(automatedWrite).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario 5: localOnly + NO existing i18n file → normal new translation
+  // -------------------------------------------------------------------------
+  it("Scenario 5: localOnly mode with no existing i18n file → creates normally", async () => {
+    const englishPage = createMockNotionPage({
+      id: "en-page-sc5",
+      title: "Test Page",
+      status: "Ready for translation",
+      language: "English",
+      order: 1,
+      parentItem: "parent-5",
+      elementType: "Page",
+      lastEdited: "2026-02-01T00:00:00.000Z",
+    });
+
+    setupCommonMocks(englishPage);
+    // i18n file does NOT exist (default in setupCommonMocks)
+    mockAccess.mockRejectedValue(new Error("ENOENT"));
+
+    const { main } = await import("../index.js");
+    const summary = await main({ localOnly: true });
+
+    expect(summary.automatedTranslations).toBe(0);
+    expect(summary.newTranslations).toBe(2); // Both PT and ES created normally
+    expect(summary.failedTranslations).toBe(0);
+
+    // localOnly → no Notion API calls
+    expect(mockNotionPagesCreate).not.toHaveBeenCalled();
+    expect(mockNotionPagesUpdate).not.toHaveBeenCalled();
+
+    // Normal i18n path used (not automated-translations/)
+    const writeCalls = mockWriteFile.mock.calls.map(
+      ([p]: [string]) => p as string
+    );
+    const automatedWrite = writeCalls.some((p) =>
+      p.includes("automated-translations")
+    );
+    expect(automatedWrite).toBe(false);
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario 6: verification-error updateKind → automated path (safe default)
+  // -------------------------------------------------------------------------
+  it("Scenario 6: block check throws → verification-error → routes to automated path", async () => {
+    const englishPage = createMockNotionPage({
+      id: "en-page-sc6",
+      title: "Test Page",
+      status: "Ready for translation",
+      language: "English",
+      order: 1,
+      parentItem: "parent-6",
+      elementType: "Page",
+      lastEdited: "2026-01-01T00:00:00.000Z", // Same date — would normally skip
+    });
+    const ptTranslation = createMockNotionPage({
+      id: "pt-page-sc6",
+      title: "Página de Teste",
+      status: "Auto Translation Generated",
+      language: "Portuguese",
+      order: 1,
+      parentItem: "parent-6",
+      elementType: "Page",
+      lastEdited: "2026-01-01T00:00:00.000Z", // Same date as English
+    });
+
+    setupCommonMocks(englishPage, { Portuguese: ptTranslation });
+    // Simulate block count API failure only for the PT translation page → verification-error
+    // English and other pages work normally (needed for translateNotionBlocksDirectly)
+    mockBlocksChildrenList.mockImplementation(
+      async ({ block_id }: { block_id: string }) => {
+        if (block_id === ptTranslation.id) {
+          throw new Error("API timeout");
+        }
+        return {
+          results: [
+            {
+              type: "heading_1",
+              has_children: false,
+              heading_1: { rich_text: [{ plain_text: "Content" }] },
+            },
+          ],
+          has_more: false,
+          next_cursor: null,
+        };
+      }
+    );
+
+    const { main } = await import("../index.js");
+    const summary = await main({});
+
+    // verification-error routes to automated path (safe default — never overwrites)
+    expect(summary.automatedTranslations).toBe(1); // PT → automated
+    expect(summary.newTranslations).toBe(1); // ES → new
+    expect(summary.updatedTranslations).toBe(0);
+    expect(summary.failedTranslations).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario 7: Toggle page in automated path → skipped
+  // -------------------------------------------------------------------------
+  it("Scenario 7: toggle page routed to automated path → skipped gracefully", async () => {
+    const toggleEnglishPage = createMockNotionPage({
+      id: "en-toggle-sc7",
+      title: "Toggle Section",
+      status: "Ready for translation",
+      language: "English",
+      order: 1,
+      parentItem: "parent-7",
+      elementType: "toggle",
+      lastEdited: "2026-02-01T00:00:00.000Z", // English newer
+    });
+    const ptToggleTranslation = createMockNotionPage({
+      id: "pt-toggle-sc7",
+      title: "Seção Toggle",
+      status: "Auto Translation Generated",
+      language: "Portuguese",
+      order: 1,
+      parentItem: "parent-7",
+      elementType: "toggle",
+      lastEdited: "2026-01-01T00:00:00.000Z", // Translation older
+    });
+
+    setupCommonMocks(toggleEnglishPage, { Portuguese: ptToggleTranslation });
+    // resolveCanonicalDocsRelativePath returns null for toggle pages
+    mockResolveCanonicalDocsRelativePath.mockReturnValue(null);
+
+    const { main } = await import("../index.js");
+    const summary = await main({});
+
+    // Toggle pages are skipped in both automated and normal paths
+    expect(summary.failedTranslations).toBe(0);
+    expect(summary.automatedTranslations).toBe(0); // Toggle skipped
+  });
+});

--- a/scripts/notion-translate/__tests__/no-overwrite.test.ts
+++ b/scripts/notion-translate/__tests__/no-overwrite.test.ts
@@ -28,11 +28,16 @@ const mockBlocksChildrenList = vi.fn();
 const mockPagesRetrieve = vi.fn();
 const mockResolveCanonicalDocsRelativePath = vi.fn();
 const mockNotionDataSourcesQuery = vi.fn();
+const mockNotionDatabasesRetrieve = vi.fn();
 const mockNotionPagesCreate = vi.fn();
 const mockNotionPagesUpdate = vi.fn();
 const mockNotionBlocksChildrenList = vi.fn();
 const mockNotionBlocksChildrenAppend = vi.fn();
 const mockNotionBlocksDelete = vi.fn();
+const defaultMockDatabaseId = "test-database-id";
+const defaultMockDataSourceId = "test-data-source-id";
+let mockDatabaseId: string | undefined = defaultMockDatabaseId;
+let mockDataSourceId: string | undefined = defaultMockDataSourceId;
 const mockSchedulerDestroy = vi.fn();
 const mockGetRequestScheduler = vi.fn(() => ({
   destroy: mockSchedulerDestroy,
@@ -57,6 +62,7 @@ vi.mock("fs/promises", () => ({
 vi.mock("../../notionClient", () => ({
   notion: {
     dataSources: { query: mockNotionDataSourcesQuery },
+    databases: { retrieve: mockNotionDatabasesRetrieve },
     pages: { create: mockNotionPagesCreate, update: mockNotionPagesUpdate },
     blocks: {
       children: {
@@ -66,8 +72,12 @@ vi.mock("../../notionClient", () => ({
       delete: mockNotionBlocksDelete,
     },
   },
-  DATABASE_ID: "test-database-id",
-  DATA_SOURCE_ID: "test-data-source-id",
+  get DATABASE_ID() {
+    return mockDatabaseId;
+  },
+  get DATA_SOURCE_ID() {
+    return mockDataSourceId;
+  },
   n2m: mockN2m,
   enhancedNotion: {
     dataSourcesQuery: mockNotionDataSourcesQuery,
@@ -112,6 +122,19 @@ type FilterCondition = {
   relation?: { contains?: string };
 };
 
+function createLanguageSchemaResponse(optionNames: string[] = []) {
+  return {
+    properties: {
+      Language: {
+        type: "select",
+        select: {
+          options: optionNames.map((name) => ({ name })),
+        },
+      },
+    },
+  };
+}
+
 function setupCommonMocks(
   englishPage: ReturnType<typeof createMockNotionPage>,
   translationsByLanguage: Record<
@@ -155,6 +178,14 @@ function setupCommonMocks(
     results: [],
     has_more: false,
   });
+  mockNotionDatabasesRetrieve.mockResolvedValue(
+    createLanguageSchemaResponse([
+      "Portuguese",
+      "Spanish",
+      "PT - automated",
+      "ES - automated",
+    ])
+  );
   mockNotionPagesCreate.mockResolvedValue({ id: "new-page-id" });
   mockNotionPagesUpdate.mockResolvedValue({});
   mockNotionBlocksChildrenList.mockResolvedValue({
@@ -237,6 +268,14 @@ function setupThreeLevelMocks(
     results: [],
     has_more: false,
   });
+  mockNotionDatabasesRetrieve.mockResolvedValue(
+    createLanguageSchemaResponse([
+      "Portuguese",
+      "Spanish",
+      "PT - automated",
+      "ES - automated",
+    ])
+  );
   mockNotionPagesCreate.mockResolvedValue({ id: "new-page-id" });
   mockNotionPagesUpdate.mockResolvedValue({});
   mockNotionBlocksChildrenList.mockResolvedValue({
@@ -275,7 +314,10 @@ describe("no-overwrite translation routing (Issue #171)", () => {
 
   beforeEach(() => {
     restoreEnv = installTestNotionEnv();
+    vi.resetModules();
     vi.resetAllMocks();
+    mockDatabaseId = defaultMockDatabaseId;
+    mockDataSourceId = defaultMockDataSourceId;
     // Re-wire mocks after reset
     mockGetRequestScheduler.mockReturnValue({ destroy: mockSchedulerDestroy });
   });
@@ -447,6 +489,7 @@ describe("no-overwrite translation routing (Issue #171)", () => {
     expect(summary.failedTranslations).toBe(0);
 
     // localOnly → no Notion API calls
+    expect(mockNotionDatabasesRetrieve).not.toHaveBeenCalled();
     expect(mockNotionPagesCreate).not.toHaveBeenCalled();
     expect(mockNotionPagesUpdate).not.toHaveBeenCalled();
 
@@ -560,7 +603,7 @@ describe("no-overwrite translation routing (Issue #171)", () => {
   // -------------------------------------------------------------------------
   // Scenario 7: Toggle page in automated path → skipped
   // -------------------------------------------------------------------------
-  it("Scenario 7: toggle page routed to automated path → skipped gracefully", async () => {
+  it("Scenario 7: toggle page routed to automated path → skipped at gate before automated processing", async () => {
     const toggleEnglishPage = createMockNotionPage({
       id: "en-toggle-sc7",
       title: "Toggle Section",
@@ -581,17 +624,36 @@ describe("no-overwrite translation routing (Issue #171)", () => {
       elementType: "toggle",
       lastEdited: "2026-01-01T00:00:00.000Z", // Translation older
     });
+    const esToggleTranslation = createMockNotionPage({
+      id: "es-toggle-sc7",
+      title: "Sección Toggle",
+      status: "Auto Translation Generated",
+      language: "Spanish",
+      order: 1,
+      parentItem: "parent-7",
+      elementType: "toggle",
+      lastEdited: "2026-01-01T00:00:00.000Z", // Translation older
+    });
 
-    setupCommonMocks(toggleEnglishPage, { Portuguese: ptToggleTranslation });
-    // resolveCanonicalDocsRelativePath returns null for toggle pages
+    setupCommonMocks(toggleEnglishPage, {
+      Portuguese: ptToggleTranslation,
+      Spanish: esToggleTranslation,
+    });
     mockResolveCanonicalDocsRelativePath.mockReturnValue(null);
 
     const { main } = await import("../index.js");
     const summary = await main({});
 
-    // Toggle pages are skipped in both automated and normal paths
     expect(summary.failedTranslations).toBe(0);
-    expect(summary.automatedTranslations).toBe(0); // Toggle skipped
+    expect(summary.automatedTranslations).toBe(0);
+    expect(summary.skippedTranslations).toBe(2);
+    expect(mockNotionPagesCreate).not.toHaveBeenCalled();
+    expect(mockNotionDatabasesRetrieve).not.toHaveBeenCalled();
+
+    const automatedWrite = mockWriteFile.mock.calls.some(([p]) =>
+      String(p).includes("automated-translations")
+    );
+    expect(automatedWrite).toBe(false);
   });
 
   // -------------------------------------------------------------------------
@@ -732,5 +794,383 @@ describe("no-overwrite translation routing (Issue #171)", () => {
       p.includes("automated-translations")
     );
     expect(automatedWrite).toBe(true);
+  });
+
+  it("Scenario 10: missing automated select options → reports TranslationError", async () => {
+    const englishPage = createMockNotionPage({
+      id: "en-page-sc10",
+      title: "Automated Validation Page",
+      status: "Ready for translation",
+      language: "English",
+      order: 1,
+      parentItem: "parent-10",
+      elementType: "Page",
+      lastEdited: "2026-02-01T00:00:00.000Z",
+    });
+    const ptTranslation = createMockNotionPage({
+      id: "pt-page-sc10",
+      title: "Página de Validação",
+      status: "Auto Translation Generated",
+      language: "Portuguese",
+      order: 1,
+      parentItem: "parent-10",
+      elementType: "Page",
+      lastEdited: "2026-01-01T00:00:00.000Z",
+    });
+    const esTranslation = createMockNotionPage({
+      id: "es-page-sc10",
+      title: "Página de Validación",
+      status: "Auto Translation Generated",
+      language: "Spanish",
+      order: 1,
+      parentItem: "parent-10",
+      elementType: "Page",
+      lastEdited: "2026-03-01T00:00:00.000Z",
+    });
+
+    setupCommonMocks(englishPage, {
+      Portuguese: ptTranslation,
+      Spanish: esTranslation,
+    });
+    mockNotionDatabasesRetrieve.mockResolvedValue(
+      createLanguageSchemaResponse(["Portuguese", "Spanish"])
+    );
+
+    const { main } = await import("../index.js");
+    await expect(main({})).rejects.toThrow(
+      "Translation workflow completed with failures (docs: 1, code.json: 0, theme: 0)"
+    );
+
+    expect(mockNotionDatabasesRetrieve).toHaveBeenCalledTimes(1);
+    expect(mockNotionPagesCreate).not.toHaveBeenCalled();
+  });
+
+  it("Scenario 11: missing DATABASE_ID logs warning and continues automated processing", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const englishPage = createMockNotionPage({
+      id: "en-page-sc11",
+      title: "Automated Warning Page",
+      status: "Ready for translation",
+      language: "English",
+      order: 1,
+      parentItem: "parent-11",
+      elementType: "Page",
+      lastEdited: "2026-02-01T00:00:00.000Z",
+    });
+    const ptTranslation = createMockNotionPage({
+      id: "pt-page-sc11",
+      title: "Página de Aviso",
+      status: "Auto Translation Generated",
+      language: "Portuguese",
+      order: 1,
+      parentItem: "parent-11",
+      elementType: "Page",
+      lastEdited: "2026-01-01T00:00:00.000Z",
+    });
+    const esTranslation = createMockNotionPage({
+      id: "es-page-sc11",
+      title: "Página de Aviso ES",
+      status: "Auto Translation Generated",
+      language: "Spanish",
+      order: 1,
+      parentItem: "parent-11",
+      elementType: "Page",
+      lastEdited: "2026-03-01T00:00:00.000Z",
+    });
+
+    setupCommonMocks(englishPage, {
+      Portuguese: ptTranslation,
+      Spanish: esTranslation,
+    });
+    mockDatabaseId = undefined;
+    delete process.env.DATABASE_ID;
+    process.env.DATA_SOURCE_ID = defaultMockDataSourceId;
+
+    const { main } = await import("../index.js");
+    const summary = await main({});
+
+    expect(summary.automatedTranslations).toBe(1);
+    expect(summary.failedTranslations).toBe(0);
+    expect(summary.skippedTranslations).toBe(1);
+    expect(mockNotionDatabasesRetrieve).not.toHaveBeenCalled();
+    expect(mockNotionPagesCreate).toHaveBeenCalledTimes(1);
+    expect(warnSpy).toHaveBeenCalledWith(
+      "Cannot verify automated language select options without DATABASE_ID — ensure they exist in Notion"
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it("Scenario 12: successful automated option validation → automated processing continues", async () => {
+    const englishPage = createMockNotionPage({
+      id: "en-page-sc11",
+      title: "Automated Success Page",
+      status: "Ready for translation",
+      language: "English",
+      order: 1,
+      parentItem: "parent-11",
+      elementType: "Page",
+      lastEdited: "2026-02-01T00:00:00.000Z",
+    });
+    const ptTranslation = createMockNotionPage({
+      id: "pt-page-sc11",
+      title: "Página de Sucesso",
+      status: "Auto Translation Generated",
+      language: "Portuguese",
+      order: 1,
+      parentItem: "parent-11",
+      elementType: "Page",
+      lastEdited: "2026-01-01T00:00:00.000Z",
+    });
+    const esTranslation = createMockNotionPage({
+      id: "es-page-sc11",
+      title: "Página de Éxito",
+      status: "Auto Translation Generated",
+      language: "Spanish",
+      order: 1,
+      parentItem: "parent-11",
+      elementType: "Page",
+      lastEdited: "2026-03-01T00:00:00.000Z",
+    });
+
+    setupCommonMocks(englishPage, {
+      Portuguese: ptTranslation,
+      Spanish: esTranslation,
+    });
+
+    const { main } = await import("../index.js");
+    const summary = await main({});
+
+    expect(summary.automatedTranslations).toBe(1);
+    expect(summary.failedTranslations).toBe(0);
+    expect(summary.skippedTranslations).toBe(1);
+    expect(mockNotionDatabasesRetrieve).toHaveBeenCalledTimes(1);
+    expect(mockNotionPagesCreate).toHaveBeenCalledTimes(1);
+  });
+
+  it("Scenario 13: automated language validation runs once per process", async () => {
+    const englishPage = createMockNotionPage({
+      id: "en-page-sc12",
+      title: "Automated Cache Page",
+      status: "Ready for translation",
+      language: "English",
+      order: 1,
+      parentItem: "parent-12",
+      elementType: "Page",
+      lastEdited: "2026-02-01T00:00:00.000Z",
+    });
+    const ptTranslation = createMockNotionPage({
+      id: "pt-page-sc12",
+      title: "Página Cache PT",
+      status: "Auto Translation Generated",
+      language: "Portuguese",
+      order: 1,
+      parentItem: "parent-12",
+      elementType: "Page",
+      lastEdited: "2026-01-01T00:00:00.000Z",
+    });
+    const esTranslation = createMockNotionPage({
+      id: "es-page-sc12",
+      title: "Página Cache ES",
+      status: "Auto Translation Generated",
+      language: "Spanish",
+      order: 1,
+      parentItem: "parent-12",
+      elementType: "Page",
+      lastEdited: "2026-01-01T00:00:00.000Z",
+    });
+
+    setupCommonMocks(englishPage, {
+      Portuguese: ptTranslation,
+      Spanish: esTranslation,
+    });
+
+    const { main } = await import("../index.js");
+    const summary = await main({});
+
+    expect(summary.automatedTranslations).toBe(2);
+    expect(summary.failedTranslations).toBe(0);
+    expect(mockNotionDatabasesRetrieve).toHaveBeenCalledTimes(1);
+    expect(mockNotionPagesCreate).toHaveBeenCalledTimes(2);
+  });
+
+  it("Scenario 14: automated block translation failure skips Notion page creation but still saves disk artifact", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const englishPage = createMockNotionPage({
+      id: "en-page-sc14",
+      title: "Automated Block Failure Page",
+      status: "Ready for translation",
+      language: "English",
+      order: 1,
+      parentItem: "parent-14",
+      elementType: "Page",
+      lastEdited: "2026-02-01T00:00:00.000Z",
+    });
+    const ptTranslation = createMockNotionPage({
+      id: "pt-page-sc14",
+      title: "Página com Falha de Blocos",
+      status: "Auto Translation Generated",
+      language: "Portuguese",
+      order: 1,
+      parentItem: "parent-14",
+      elementType: "Page",
+      lastEdited: "2026-01-01T00:00:00.000Z",
+    });
+    const esTranslation = createMockNotionPage({
+      id: "es-page-sc14",
+      title: "Página con Bloques",
+      status: "Auto Translation Generated",
+      language: "Spanish",
+      order: 1,
+      parentItem: "parent-14",
+      elementType: "Page",
+      lastEdited: "2026-03-01T00:00:00.000Z",
+    });
+
+    setupCommonMocks(englishPage, {
+      Portuguese: ptTranslation,
+      Spanish: esTranslation,
+    });
+    mockBlocksChildrenList.mockImplementation(
+      async ({ block_id }: { block_id: string }) => {
+        if (block_id === englishPage.id) {
+          throw new Error("block translation failed");
+        }
+        return {
+          results: [
+            {
+              type: "heading_1",
+              has_children: false,
+              heading_1: { rich_text: [{ plain_text: "Content" }] },
+            },
+          ],
+          has_more: false,
+          next_cursor: null,
+        };
+      }
+    );
+
+    const { main } = await import("../index.js");
+    const summary = await main({});
+
+    expect(summary.automatedTranslations).toBe(1);
+    expect(summary.failedTranslations).toBe(0);
+    expect(summary.skippedTranslations).toBe(1);
+    expect(mockNotionPagesCreate).not.toHaveBeenCalled();
+
+    const writePaths = mockWriteFile.mock.calls.map(([filePath]) =>
+      String(filePath)
+    );
+    expect(
+      writePaths.some(
+        (filePath) =>
+          filePath.includes("automated-translations") &&
+          filePath.endsWith(".md")
+      )
+    ).toBe(true);
+    expect(
+      writePaths.some((filePath) => filePath.endsWith(".notion.json"))
+    ).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Could not translate Notion blocks for "Automated Block Failure Page": block translation failed — skipping Notion page creation to avoid an empty page'
+      )
+    );
+
+    warnSpy.mockRestore();
+  });
+
+  it("Scenario 15: empty translated Notion blocks skip Notion page creation but still save disk artifact", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    const englishPage = createMockNotionPage({
+      id: "en-page-sc15",
+      title: "Automated Empty Blocks Page",
+      status: "Ready for translation",
+      language: "English",
+      order: 1,
+      parentItem: "parent-15",
+      elementType: "Page",
+      lastEdited: "2026-02-01T00:00:00.000Z",
+    });
+    const ptTranslation = createMockNotionPage({
+      id: "pt-page-sc15",
+      title: "Página com Blocos Vazios",
+      status: "Auto Translation Generated",
+      language: "Portuguese",
+      order: 1,
+      parentItem: "parent-15",
+      elementType: "Page",
+      lastEdited: "2026-01-01T00:00:00.000Z",
+    });
+    const esTranslation = createMockNotionPage({
+      id: "es-page-sc15",
+      title: "Página con Bloques Vacíos",
+      status: "Auto Translation Generated",
+      language: "Spanish",
+      order: 1,
+      parentItem: "parent-15",
+      elementType: "Page",
+      lastEdited: "2026-03-01T00:00:00.000Z",
+    });
+
+    setupCommonMocks(englishPage, {
+      Portuguese: ptTranslation,
+      Spanish: esTranslation,
+    });
+    mockBlocksChildrenList.mockImplementation(
+      async ({ block_id }: { block_id: string }) => {
+        if (block_id === englishPage.id) {
+          return {
+            results: [],
+            has_more: false,
+            next_cursor: null,
+          };
+        }
+
+        return {
+          results: [
+            {
+              type: "heading_1",
+              has_children: false,
+              heading_1: { rich_text: [{ plain_text: "Content" }] },
+            },
+          ],
+          has_more: false,
+          next_cursor: null,
+        };
+      }
+    );
+
+    const { main } = await import("../index.js");
+    const summary = await main({});
+
+    expect(summary.automatedTranslations).toBe(1);
+    expect(summary.failedTranslations).toBe(0);
+    expect(summary.skippedTranslations).toBe(1);
+    expect(mockNotionPagesCreate).not.toHaveBeenCalled();
+
+    const writePaths = mockWriteFile.mock.calls.map(([filePath]) =>
+      String(filePath)
+    );
+    expect(
+      writePaths.some(
+        (filePath) =>
+          filePath.includes("automated-translations") &&
+          filePath.endsWith(".md")
+      )
+    ).toBe(true);
+    expect(
+      writePaths.some((filePath) => filePath.endsWith(".notion.json"))
+    ).toBe(false);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Translated Notion blocks for "Automated Empty Blocks Page" were empty — skipping Notion page creation to avoid an empty page'
+      )
+    );
+
+    warnSpy.mockRestore();
   });
 });

--- a/scripts/notion-translate/__tests__/no-overwrite.test.ts
+++ b/scripts/notion-translate/__tests__/no-overwrite.test.ts
@@ -185,6 +185,88 @@ function setupCommonMocks(
 }
 
 // ---------------------------------------------------------------------------
+// Helper: set up mocks for three-level hierarchy (ParentContainer → ChildEnglish,
+// ChildPT).  The key difference from setupCommonMocks is that the "Publish Status"
+// filter returns MULTIPLE English pages (both ParentContainer and ChildEnglish),
+// matching how fetchPublishedEnglishPages() returns all Language=English pages.
+// ---------------------------------------------------------------------------
+
+function setupThreeLevelMocks(
+  englishPages: ReturnType<typeof createMockNotionPage>[],
+  translationsByLanguage: Record<
+    string,
+    ReturnType<typeof createMockNotionPage>
+  > = {}
+) {
+  // Collect all page IDs that should resolve to a canonical path
+  const canonicalPageIds = new Set(englishPages.map((p) => p.id));
+
+  mockFetchNotionData.mockImplementation(async (filter: unknown) => {
+    const f = filter as { and?: FilterCondition[] };
+    // English page fetch (Publish Status filter or no filter)
+    if (f?.and?.some((c) => c.property === "Publish Status") || !f?.and) {
+      return englishPages;
+    }
+    // Translation lookup (Parent item + Language)
+    const langCondition = f?.and?.find((c) => c.property === "Language");
+    if (langCondition?.select?.equals) {
+      const lang = langCondition.select.equals;
+      return translationsByLanguage[lang] ? [translationsByLanguage[lang]] : [];
+    }
+    return [];
+  });
+  mockSortAndExpandNotionData.mockImplementation(
+    async (pages: unknown[]) => pages
+  );
+  mockN2m.pageToMarkdown.mockResolvedValue([]);
+  mockN2m.toMarkdownString.mockReturnValue({
+    parent: "# Translated\n\nContent",
+  });
+  mockBlocksChildrenList.mockResolvedValue({
+    results: [
+      {
+        type: "heading_1",
+        has_children: false,
+        heading_1: { rich_text: [{ plain_text: "Translated content" }] },
+      },
+    ],
+    has_more: false,
+    next_cursor: null,
+  });
+  mockNotionDataSourcesQuery.mockResolvedValue({
+    results: [],
+    has_more: false,
+  });
+  mockNotionPagesCreate.mockResolvedValue({ id: "new-page-id" });
+  mockNotionPagesUpdate.mockResolvedValue({});
+  mockNotionBlocksChildrenList.mockResolvedValue({
+    results: [],
+    has_more: false,
+  });
+  mockNotionBlocksChildrenAppend.mockResolvedValue({});
+  mockNotionBlocksDelete.mockResolvedValue({});
+  mockTranslateText.mockResolvedValue({
+    markdown: "# Traduzido",
+    title: "Traduzido",
+  });
+  mockTranslateJson.mockResolvedValue("{}");
+  mockExtractTranslatableText.mockReturnValue({});
+  mockGetLanguageName.mockImplementation((lang: string) =>
+    lang === "pt" ? "Portuguese" : "Spanish"
+  );
+  mockResolveCanonicalDocsRelativePath.mockImplementation((pageId: string) =>
+    canonicalPageIds.has(pageId) ? "test-page.md" : null
+  );
+  // Default: i18n file does NOT exist
+  mockAccess.mockRejectedValue(new Error("ENOENT"));
+  mockReadFile.mockResolvedValue("");
+  mockWriteFile.mockResolvedValue(undefined);
+  mockMkdir.mockResolvedValue(undefined);
+  // translateThemeConfig needs readdir to return an iterable
+  mockReaddir.mockResolvedValue([]);
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -510,5 +592,145 @@ describe("no-overwrite translation routing (Issue #171)", () => {
     // Toggle pages are skipped in both automated and normal paths
     expect(summary.failedTranslations).toBe(0);
     expect(summary.automatedTranslations).toBe(0); // Toggle skipped
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario 8: Three-level hierarchy — sibling matching via shared container
+  //
+  // Hierarchy: ParentContainer (English, no Parent item)
+  //              ├── ChildEnglish (English, Parent item → ParentContainer)
+  //              └── ChildPT      (Portuguese, Parent item → ParentContainer)
+  //
+  // When main() processes ChildEnglish, findTranslationPage() queries for
+  // pages with Parent item = ParentContainer.id AND Language = Portuguese,
+  // which returns ChildPT.  The test does NOT use --local-only.
+  // -------------------------------------------------------------------------
+  it("Scenario 8: three-level hierarchy — ChildEnglish resolves ChildPT via shared container", async () => {
+    const containerId = "parent-container-sc8";
+
+    const childEnglish = createMockNotionPage({
+      id: "child-en-sc8",
+      title: "Child English Page",
+      status: "Ready for translation",
+      language: "English",
+      order: 1,
+      parentItem: containerId,
+      elementType: "Page",
+      lastEdited: "2026-02-01T00:00:00.000Z", // English is NEWER
+    });
+    const childPT = createMockNotionPage({
+      id: "child-pt-sc8",
+      title: "Página em Português",
+      status: "Auto Translation Generated",
+      language: "Portuguese",
+      order: 1,
+      parentItem: containerId,
+      elementType: "Page",
+      lastEdited: "2026-01-01T00:00:00.000Z", // Translation is OLDER
+    });
+
+    // Only ChildEnglish in the English page set (container excluded)
+    setupThreeLevelMocks([childEnglish], {
+      Portuguese: childPT,
+    });
+
+    const { main } = await import("../index.js");
+    const summary = await main({});
+
+    // Portuguese → automated path (ChildEnglish newer, existing PT found via container)
+    // Spanish → normal new translation path (no existing translation)
+    expect(summary.automatedTranslations).toBe(1);
+    expect(summary.newTranslations).toBe(1); // Spanish
+    expect(summary.updatedTranslations).toBe(0);
+    expect(summary.failedTranslations).toBe(0);
+
+    // Automated path always creates (forceCreate) — never updates
+    expect(mockNotionPagesCreate).toHaveBeenCalledTimes(2); // 1 automated PT + 1 new ES
+    expect(mockNotionPagesUpdate).toHaveBeenCalledTimes(0);
+
+    // Disk write to automated-translations/ directory
+    const writeCalls = mockWriteFile.mock.calls.map(
+      ([p]: [string]) => p as string
+    );
+    const automatedWrite = writeCalls.some((p) =>
+      p.includes("automated-translations")
+    );
+    expect(automatedWrite).toBe(true);
+  });
+
+  // -------------------------------------------------------------------------
+  // Scenario 9: Batch-mode with container — ParentContainer skipped, ChildEnglish processed
+  //
+  // Hierarchy: ParentContainer (English, no Parent item)
+  //              ├── ChildEnglish (English, Parent item → ParentContainer)
+  //              └── ChildPT      (Portuguese, Parent item → ParentContainer)
+  //
+  // fetchPublishedEnglishPages() returns BOTH ParentContainer and ChildEnglish.
+  // ParentContainer is skipped (no Parent item relation in batch mode).
+  // ChildEnglish is processed and reaches the automated no-overwrite path.
+  // -------------------------------------------------------------------------
+  it("Scenario 9: batch-mode with container — container skipped, child processed", async () => {
+    const containerId = "parent-container-sc9";
+
+    const parentContainer = createMockNotionPage({
+      id: containerId,
+      title: "Parent Container",
+      status: "Ready for translation",
+      language: "English",
+      order: 0,
+      // No parentItem — this is the top-level container
+      elementType: "Page",
+      lastEdited: "2026-02-01T00:00:00.000Z",
+    });
+    const childEnglish = createMockNotionPage({
+      id: "child-en-sc9",
+      title: "Child English Page",
+      status: "Ready for translation",
+      language: "English",
+      order: 1,
+      parentItem: containerId,
+      elementType: "Page",
+      lastEdited: "2026-02-01T00:00:00.000Z", // English is NEWER
+    });
+    const childPT = createMockNotionPage({
+      id: "child-pt-sc9",
+      title: "Página em Português",
+      status: "Auto Translation Generated",
+      language: "Portuguese",
+      order: 1,
+      parentItem: containerId,
+      elementType: "Page",
+      lastEdited: "2026-01-01T00:00:00.000Z", // Translation is OLDER
+    });
+
+    // Both ParentContainer and ChildEnglish returned by fetchPublishedEnglishPages
+    setupThreeLevelMocks([parentContainer, childEnglish], {
+      Portuguese: childPT,
+    });
+
+    const { main } = await import("../index.js");
+    const summary = await main({});
+
+    // ParentContainer is skipped (no Parent item) — counted once per language
+    // ChildEnglish: PT → automated (English newer, existing PT found), ES → new
+    // Total skips = 2 (ParentContainer skipped for both PT and ES)
+    expect(summary.skippedTranslations).toBe(2);
+    expect(summary.automatedTranslations).toBe(1); // ChildEnglish PT → automated
+    expect(summary.newTranslations).toBe(1); // ChildEnglish ES → new
+    expect(summary.updatedTranslations).toBe(0);
+    expect(summary.failedTranslations).toBe(0);
+
+    // 1 automated PT page + 1 new ES page (container generates no pages)
+    expect(mockNotionPagesCreate).toHaveBeenCalledTimes(2);
+    expect(mockNotionPagesUpdate).toHaveBeenCalledTimes(0);
+
+    // Disk write to automated-translations/ directory
+    const writeCalls = mockWriteFile.mock.calls.map(
+      ([p]: [string]) => p as string
+    );
+    const automatedWrite = writeCalls.some((p) =>
+      p.includes("automated-translations")
+    );
+    expect(automatedWrite).toBe(true);
   });
 });

--- a/scripts/notion-translate/index.test.ts
+++ b/scripts/notion-translate/index.test.ts
@@ -3064,4 +3064,31 @@ describe("notion-translate index", () => {
       expect(sidecarWrite).toBeUndefined();
     });
   });
+
+  describe("getTranslatedBlocksForDisk", () => {
+    it("requires parent metadata before replay blocks are eligible for disk writes", async () => {
+      const { getTranslatedBlocksForDisk } = await import("./index");
+
+      const translatedBlocks = [
+        { type: "paragraph", paragraph: { rich_text: [] } },
+      ] as any;
+
+      expect(
+        getTranslatedBlocksForDisk({
+          localOnly: false,
+          skipNotionPageCreation: false,
+          translatedBlocks,
+        })
+      ).toBeUndefined();
+
+      expect(
+        getTranslatedBlocksForDisk({
+          localOnly: false,
+          skipNotionPageCreation: false,
+          translatedBlocks,
+          parentId: "parent-789",
+        })
+      ).toBe(translatedBlocks);
+    });
+  });
 });

--- a/scripts/notion-translate/index.test.ts
+++ b/scripts/notion-translate/index.test.ts
@@ -25,6 +25,7 @@ const mockNotionPagesUpdate = vi.fn();
 const mockNotionBlocksChildrenList = vi.fn();
 const mockNotionBlocksChildrenAppend = vi.fn();
 const mockNotionBlocksDelete = vi.fn();
+const mockNotionDatabasesRetrieve = vi.fn();
 const mockSchedulerDestroy = vi.fn();
 const mockGetRequestScheduler = vi.fn(() => ({
   destroy: mockSchedulerDestroy,
@@ -50,6 +51,9 @@ vi.mock("../notionClient", () => ({
   notion: {
     dataSources: {
       query: mockNotionDataSourcesQuery,
+    },
+    databases: {
+      retrieve: mockNotionDatabasesRetrieve,
     },
     pages: {
       create: mockNotionPagesCreate,
@@ -146,6 +150,7 @@ describe("notion-translate index", () => {
     mockNotionBlocksChildrenList.mockReset();
     mockNotionBlocksChildrenAppend.mockReset();
     mockNotionBlocksDelete.mockReset();
+    mockNotionDatabasesRetrieve.mockReset();
     mockN2m.pageToMarkdown.mockReset();
     mockN2m.toMarkdownString.mockReset();
     mockSchedulerDestroy.mockReset();
@@ -192,6 +197,21 @@ describe("notion-translate index", () => {
     });
     mockNotionBlocksChildrenAppend.mockResolvedValue({});
     mockNotionBlocksDelete.mockResolvedValue({});
+    mockNotionDatabasesRetrieve.mockResolvedValue({
+      properties: {
+        Language: {
+          select: {
+            options: [
+              { name: "English" },
+              { name: "Portuguese" },
+              { name: "Spanish" },
+              { name: "PT - automated" },
+              { name: "ES - automated" },
+            ],
+          },
+        },
+      },
+    });
     mockTranslateText.mockResolvedValue({
       markdown: "# Ola",
       title: "Ola",
@@ -258,6 +278,11 @@ describe("notion-translate index", () => {
     mockStat.mockResolvedValue({
       isDirectory: () => true,
     });
+  });
+
+  afterEach(() => {
+    restoreEnv();
+    vi.restoreAllMocks();
   });
 
   describe("needsTranslationUpdate", () => {
@@ -337,6 +362,44 @@ describe("notion-translate index", () => {
       });
     });
 
+    it("skips update when translation has Human Reviewed status and has content", async () => {
+      const englishPage = createMockNotionPage({
+        id: "english-page-1",
+        title: "Hello World",
+        status: "Ready for translation",
+        language: "English",
+        lastEdited: "2026-02-01T00:00:00.000Z",
+      });
+      const translationPage = createMockNotionPage({
+        id: "translation-page-1",
+        title: "Ola Mundo",
+        status: "Human Reviewed",
+        language: "Portuguese",
+        lastEdited: "2026-02-05T00:00:00.000Z",
+      });
+
+      mockBlocksChildrenList.mockResolvedValue({
+        results: [
+          {
+            type: "paragraph",
+            has_children: false,
+            paragraph: { rich_text: [{ plain_text: "Conteudo revisado" }] },
+          },
+        ],
+        has_more: false,
+        next_cursor: null,
+      });
+
+      const { needsTranslationUpdate } = await import("./index");
+      const result = await needsTranslationUpdate(englishPage, translationPage);
+
+      expect(result).toMatchObject({
+        needsUpdate: false,
+        reason: "Translation has content",
+        blockCount: 1,
+      });
+    });
+
     it("fails open when content inspection fails and requests update", async () => {
       const englishPage = createMockNotionPage({
         id: "english-page-1",
@@ -363,11 +426,6 @@ describe("notion-translate index", () => {
         reason: "Unable to verify translation content",
       });
     });
-  });
-
-  afterEach(() => {
-    restoreEnv();
-    vi.restoreAllMocks();
   });
 
   describe("fetchPublishedEnglishPages", () => {
@@ -1163,6 +1221,62 @@ describe("notion-translate index", () => {
       expect(mockNotionPagesUpdate).not.toHaveBeenCalled();
       expect(mockFetchNotionData).not.toHaveBeenCalled();
       expect(mockSortAndExpandNotionData).not.toHaveBeenCalled();
+    });
+
+    it("routes Human Reviewed translation to automated path when English is newer", async () => {
+      const sourcePageId = "2641b08162d580359153cac75e4f09f2";
+      const englishPage = createMockNotionPage({
+        id: sourcePageId,
+        title: "EN Page With Human Reviewed Translation",
+        status: "Ready for translation",
+        language: "English",
+        order: 4,
+        parentItem: "parent-hr",
+        elementType: "Page",
+        lastEdited: "2026-02-01T00:00:00.000Z",
+      });
+      const humanReviewedTranslation = createMockNotionPage({
+        id: "hr-translation-id",
+        title: "PT Human Reviewed",
+        status: "Human Reviewed",
+        language: "Portuguese",
+        order: 4,
+        parentItem: "parent-hr",
+        elementType: "Page",
+        lastEdited: "2026-01-01T00:00:00.000Z",
+      });
+
+      mockPagesRetrieve.mockResolvedValue(englishPage);
+      mockFetchNotionData.mockImplementation(async (filter) => {
+        const hasParentItem = filter?.and?.some(
+          (condition: {
+            property?: string;
+            relation?: { contains?: string };
+          }) =>
+            condition.property === "Parent item" &&
+            condition.relation?.contains === "parent-hr"
+        );
+        if (hasParentItem) {
+          const langCondition = filter?.and?.find(
+            (c: { property?: string }) => c.property === "Language"
+          ) as { select?: { equals?: string } } | undefined;
+          if (langCondition?.select?.equals === "Portuguese") {
+            return [humanReviewedTranslation];
+          }
+          return [];
+        }
+        return [];
+      });
+
+      const { main } = await import("./index");
+      const summary = await main({ pageId: sourcePageId });
+
+      // Human Reviewed translation is older → English is newer → automated no-overwrite path
+      // Existing translation is not directly overwritten; a new automated page is created
+      expect(summary.failedTranslations).toBe(0);
+      expect(summary.automatedTranslations).toBe(1);
+      expect(summary.skippedTranslations).toBe(0);
+      expect(mockNotionPagesUpdate).toHaveBeenCalledTimes(0);
     });
   });
 
@@ -2401,7 +2515,8 @@ describe("notion-translate index", () => {
       // Verify failure is marked as non-critical
       expect(summary.failures).toBeDefined();
       const parentFailures = summary.failures.filter(
-        (f: any) => f.error === "Missing required Parent item relation"
+        (f: { error: string; isCritical: boolean }) =>
+          f.error === "Missing required Parent item relation"
       );
       expect(parentFailures.length).toBeGreaterThan(0);
       expect(parentFailures[0].isCritical).toBe(false);
@@ -2477,7 +2592,8 @@ describe("notion-translate index", () => {
       // Verify both outcomes are tracked
       expect(summary.failures).toBeDefined();
       const parentFailures = summary.failures.filter(
-        (f: any) => f.error === "Missing required Parent item relation"
+        (f: { error: string }) =>
+          f.error === "Missing required Parent item relation"
       );
       expect(parentFailures.length).toBeGreaterThan(0);
 
@@ -2701,6 +2817,66 @@ describe("notion-translate index", () => {
       const esResult = await findSiblingTranslations(englishPage, "Spanish");
       expect(esResult?.id).toBe(spanishSibling.id);
     });
+
+    it("three-level hierarchy: finds sibling by traversing immediate parent even when grandparent exists", async () => {
+      // Hierarchy: GrandparentContainer → ParentContainer → englishPage (+ portugueseSibling)
+      // findSiblingTranslations looks at englishPage.parent (= parentContainer),
+      // fetches parentContainer's children, and finds portugueseSibling there.
+      const parentContainerId = "parent-container-3level";
+
+      const englishPage = createMockNotionPage({
+        id: "2641b08162d580359153cac75e4f09f2",
+        title: "English Page Level 3",
+        status: "Ready for translation",
+        language: "English",
+        order: 1,
+        parentItem: undefined,
+        elementType: "Page",
+        lastEdited: "2026-02-01T00:00:00.000Z",
+      });
+      // English page's immediate parent is the parentContainer (depth 3 hierarchy)
+      (englishPage as any).parent = {
+        type: "page_id",
+        page_id: parentContainerId,
+      };
+
+      const portugueseSibling = createMockNotionPage({
+        id: "pt-sibling-3level",
+        title: "Portuguese Page Level 3",
+        status: "Auto Translation Generated",
+        language: "Portuguese",
+        order: 1,
+        parentItem: undefined,
+        elementType: "Page",
+        lastEdited: "2026-01-01T00:00:00.000Z",
+      });
+
+      mockBlocksChildrenList.mockResolvedValue({
+        results: [
+          { id: englishPage.id, type: "child_page", object: "page" },
+          { id: portugueseSibling.id, type: "child_page", object: "page" },
+        ],
+        has_more: false,
+        next_cursor: null,
+      });
+
+      mockPagesRetrieve.mockImplementation(
+        async ({ page_id }: { page_id: string }) => {
+          if (page_id === portugueseSibling.id) return portugueseSibling;
+          return englishPage;
+        }
+      );
+
+      const { findSiblingTranslations } = await import("./index");
+      const result = await findSiblingTranslations(englishPage, "Portuguese");
+
+      expect(result).not.toBeNull();
+      expect(result?.id).toBe(portugueseSibling.id);
+      // Traversal should query the immediate parent (parentContainerId), not grandparent
+      expect(mockBlocksChildrenList).toHaveBeenCalledWith({
+        block_id: parentContainerId,
+      });
+    });
   });
 
   describe("cleanup and CLI wrapper", () => {
@@ -2765,6 +2941,127 @@ describe("notion-translate index", () => {
       await vi.waitFor(() => {
         expect(processExitSpy).toHaveBeenCalledWith(1);
       });
+    });
+  });
+
+  describe("saveAutomatedTranslationToDisk sidecar sourceProperties", () => {
+    it("writes sourceProperties to sidecar when properties param is provided", async () => {
+      const { saveAutomatedTranslationToDisk } = await import("./index");
+      mockResolveCanonicalDocsRelativePath.mockReturnValueOnce(null);
+
+      const mockPage = createMockNotionPage({
+        id: "sidecar-test-page",
+        title: "Sidecar Test",
+        elementType: "Page",
+      });
+
+      const blocks = [
+        { type: "paragraph", paragraph: { rich_text: [] } },
+      ] as any;
+      const properties: Record<string, unknown> = {
+        Language: { select: { name: "PT - automated" } },
+        "Element Type": { select: { name: "Page" } },
+        Order: { number: 5 },
+        Tags: { multi_select: [{ name: "guide" }, { name: "setup" }] },
+      };
+
+      await saveAutomatedTranslationToDisk(
+        mockPage,
+        "# Content",
+        "Sidecar Test",
+        "/test/automated-output",
+        "20260412T120000",
+        blocks,
+        "parent-123",
+        properties
+      );
+
+      // Find the sidecar write
+      const sidecarWrite = mockWriteFile.mock.calls.find(
+        (call: string[]) =>
+          typeof call[0] === "string" && call[0].endsWith(".notion.json")
+      );
+      expect(sidecarWrite).toBeDefined();
+      const sidecarContent = JSON.parse(sidecarWrite![1] as string);
+
+      // sourceProperties should contain metadata but NOT Language
+      expect(sidecarContent.sourceProperties).toBeDefined();
+      expect(sidecarContent.sourceProperties["Element Type"]).toEqual({
+        select: { name: "Page" },
+      });
+      expect(sidecarContent.sourceProperties["Order"]).toEqual({
+        number: 5,
+      });
+      expect(sidecarContent.sourceProperties["Tags"]).toEqual({
+        multi_select: [{ name: "guide" }, { name: "setup" }],
+      });
+      expect(sidecarContent.sourceProperties["Language"]).toBeUndefined();
+      // Sidecar should still have blocks and parentId
+      expect(sidecarContent.blocks).toEqual(blocks);
+      expect(sidecarContent.parentId).toBe("parent-123");
+    });
+
+    it("does not write sourceProperties when properties param is omitted", async () => {
+      const { saveAutomatedTranslationToDisk } = await import("./index");
+      mockResolveCanonicalDocsRelativePath.mockReturnValueOnce(null);
+
+      const mockPage = createMockNotionPage({
+        id: "sidecar-no-props",
+        title: "No Props",
+        elementType: "Page",
+      });
+
+      const blocks = [
+        { type: "paragraph", paragraph: { rich_text: [] } },
+      ] as any;
+
+      await saveAutomatedTranslationToDisk(
+        mockPage,
+        "# Content",
+        "No Props",
+        "/test/automated-output",
+        "20260412T120000",
+        blocks,
+        "parent-456"
+        // no properties param
+      );
+
+      const sidecarWrite = mockWriteFile.mock.calls.find(
+        (call: string[]) =>
+          typeof call[0] === "string" && call[0].endsWith(".notion.json")
+      );
+      expect(sidecarWrite).toBeDefined();
+      const sidecarContent = JSON.parse(sidecarWrite![1] as string);
+
+      expect(sidecarContent.sourceProperties).toBeUndefined();
+      expect(sidecarContent.blocks).toEqual(blocks);
+      expect(sidecarContent.parentId).toBe("parent-456");
+    });
+
+    it("does not write sidecar at all when no blocks are provided", async () => {
+      const { saveAutomatedTranslationToDisk } = await import("./index");
+      mockResolveCanonicalDocsRelativePath.mockReturnValueOnce(null);
+
+      const mockPage = createMockNotionPage({
+        id: "sidecar-no-blocks",
+        title: "No Blocks",
+        elementType: "Page",
+      });
+
+      await saveAutomatedTranslationToDisk(
+        mockPage,
+        "# Content",
+        "No Blocks",
+        "/test/automated-output",
+        "20260412T120000"
+        // no blocks, no parentId, no properties
+      );
+
+      const sidecarWrite = mockWriteFile.mock.calls.find(
+        (call: string[]) =>
+          typeof call[0] === "string" && call[0].endsWith(".notion.json")
+      );
+      expect(sidecarWrite).toBeUndefined();
     });
   });
 });

--- a/scripts/notion-translate/index.test.ts
+++ b/scripts/notion-translate/index.test.ts
@@ -797,8 +797,13 @@ describe("notion-translate index", () => {
         )
       ).toBe(false);
 
-      expect(mockNotionPagesCreate).toHaveBeenCalledTimes(1);
-      expect(mockNotionPagesUpdate).toHaveBeenCalledTimes(1);
+      // Portuguese existing translation (English newer) → automated no-overwrite path → new page created
+      // Spanish (no translation) → normal new translation path → new page created
+      // No updates: the no-overwrite strategy never updates existing translations
+      expect(mockNotionPagesCreate).toHaveBeenCalledTimes(2);
+      expect(mockNotionPagesUpdate).toHaveBeenCalledTimes(0);
+      expect(summary.automatedTranslations).toBe(1);
+      expect(summary.newTranslations).toBe(1);
 
       const lookedUpBySourceId = mockFetchNotionData.mock.calls.some(
         ([filter]) =>

--- a/scripts/notion-translate/index.test.ts
+++ b/scripts/notion-translate/index.test.ts
@@ -20,6 +20,7 @@ const mockBlocksChildrenList = vi.fn();
 const mockPagesRetrieve = vi.fn();
 const mockResolveCanonicalDocsRelativePath = vi.fn();
 const mockNotionDataSourcesQuery = vi.fn();
+const mockNotionDataSourcesRetrieve = vi.fn();
 const mockNotionPagesCreate = vi.fn();
 const mockNotionPagesUpdate = vi.fn();
 const mockNotionBlocksChildrenList = vi.fn();
@@ -51,6 +52,7 @@ vi.mock("../notionClient", () => ({
   notion: {
     dataSources: {
       query: mockNotionDataSourcesQuery,
+      retrieve: mockNotionDataSourcesRetrieve,
     },
     databases: {
       retrieve: mockNotionDatabasesRetrieve,
@@ -145,6 +147,7 @@ describe("notion-translate index", () => {
     mockPagesRetrieve.mockReset();
     mockResolveCanonicalDocsRelativePath.mockReset();
     mockNotionDataSourcesQuery.mockReset();
+    mockNotionDataSourcesRetrieve.mockReset();
     mockNotionPagesCreate.mockReset();
     mockNotionPagesUpdate.mockReset();
     mockNotionBlocksChildrenList.mockReset();
@@ -187,6 +190,21 @@ describe("notion-translate index", () => {
       results: [],
       has_more: false,
       next_cursor: null,
+    });
+    mockNotionDataSourcesRetrieve.mockResolvedValue({
+      properties: {
+        Language: {
+          select: {
+            options: [
+              { name: "English" },
+              { name: "Portuguese" },
+              { name: "Spanish" },
+              { name: "PT - automated" },
+              { name: "ES - automated" },
+            ],
+          },
+        },
+      },
     });
     mockNotionPagesCreate.mockResolvedValue({ id: "new-page-id" });
     mockNotionPagesUpdate.mockResolvedValue({});

--- a/scripts/notion-translate/index.ts
+++ b/scripts/notion-translate/index.ts
@@ -1085,7 +1085,8 @@ export async function saveAutomatedTranslationToDisk(
       const hours = String(now.getHours()).padStart(2, "0");
       const minutes = String(now.getMinutes()).padStart(2, "0");
       const seconds = String(now.getSeconds()).padStart(2, "0");
-      return `${year}-${month}-${day}T${hours}${minutes}${seconds}`;
+      const ms = String(now.getMilliseconds()).padStart(3, "0");
+      return `${year}-${month}-${day}T${hours}${minutes}${seconds}${ms}`;
     })();
 
     const canonicalRelativePath = resolveCanonicalDocsRelativePath(

--- a/scripts/notion-translate/index.ts
+++ b/scripts/notion-translate/index.ts
@@ -60,8 +60,15 @@ type NotionSelectProperty = {
 type NotionNumberProperty = { number: number };
 type NotionMultiSelectProperty = { multi_select: Array<{ name: string }> };
 type NotionRelationProperty = { relation: Array<{ id: string }> };
+type NotionDatabaseSelectSchemaProperty = {
+  type?: "select";
+  select?: {
+    options?: Array<{ name?: string }>;
+  };
+};
 
 const FRONTMATTER_BLOCK_REGEX = /^---\r?\n[\s\S]*?\r?\n---\r?\n?/;
+let automatedLanguageOptionsValidated = false;
 
 // Type for Notion page parent (API hierarchy structure)
 interface NotionPageParent {
@@ -456,6 +463,48 @@ function validateRequiredEnvironment(): void {
       `Missing required environment variables: ${missingVariables.join(", ")}`
     );
   }
+}
+
+async function validateAutomatedLanguageOptions(): Promise<void> {
+  if (automatedLanguageOptionsValidated) {
+    return;
+  }
+
+  if (!DATABASE_ID) {
+    console.warn(
+      "Cannot verify automated language select options without DATABASE_ID — ensure they exist in Notion"
+    );
+    automatedLanguageOptionsValidated = true;
+    return;
+  }
+
+  const database = (await notion.databases.retrieve({
+    database_id: DATABASE_ID,
+  })) as {
+    properties?: Record<string, unknown>;
+  };
+  const languageProperty = database.properties?.[NOTION_PROPERTIES.LANGUAGE] as
+    | NotionDatabaseSelectSchemaProperty
+    | undefined;
+  const optionNames = new Set(
+    languageProperty?.select?.options
+      ?.map((option) => option.name)
+      .filter((name): name is string => Boolean(name)) ?? []
+  );
+  const requiredAutomatedOptions = ["PT - automated", "ES - automated"];
+  const missingOptions = requiredAutomatedOptions.filter(
+    (optionName) => !optionNames.has(optionName)
+  );
+
+  if (missingOptions.length > 0) {
+    throw new TranslationError(
+      `Missing automated language select options in Notion: ${missingOptions.join(", ")}`,
+      "schema_invalid",
+      true
+    );
+  }
+
+  automatedLanguageOptionsValidated = true;
 }
 
 /**
@@ -1371,6 +1420,17 @@ async function processLanguageTranslations(
     }
 
     if (automatedPathNeeded) {
+      const elementType = getElementTypeProperty(englishPage);
+      if (elementType?.select?.name?.toLowerCase() === "toggle") {
+        console.log(
+          chalk.gray(
+            `Skipping toggle page "${originalTitle}" — automated path does not handle toggles`
+          )
+        );
+        skippedTranslations++;
+        continue;
+      }
+
       try {
         await processAutomatedTranslation({
           englishPage,
@@ -1479,17 +1539,12 @@ async function processAutomatedTranslation({
 }): Promise<void> {
   const originalTitle = getTitle(englishPage);
 
-  // Skip toggle/category pages
+  if (!localOnly) {
+    await validateAutomatedLanguageOptions();
+  }
+
   const elementType = getElementTypeProperty(englishPage);
   const sectionType = elementType?.select?.name?.toLowerCase();
-  if (sectionType === "toggle") {
-    console.log(
-      chalk.gray(
-        `Skipping toggle page "${originalTitle}" — automated path does not handle toggles`
-      )
-    );
-    return;
-  }
 
   // Get automated language code (exactly once — prevents double-apply)
   const automatedLangCode = getAutomatedLanguageCode(config.notionLangCode);
@@ -1530,6 +1585,7 @@ async function processAutomatedTranslation({
 
   // Translate Notion blocks (only when not local-only)
   let translatedBlocks: any[] | undefined;
+  let skipNotionPageCreation = false;
   if (!localOnly) {
     try {
       if (!isTitlePage) {
@@ -1549,10 +1605,23 @@ async function processAutomatedTranslation({
         ];
       }
     } catch (err) {
+      skipNotionPageCreation = true;
       const msg = err instanceof Error ? err.message : String(err);
       console.warn(
         chalk.yellow(
-          `Could not translate Notion blocks for "${originalTitle}": ${msg} — Notion page will be created without translated blocks`
+          `Could not translate Notion blocks for "${originalTitle}": ${msg} — skipping Notion page creation to avoid an empty page`
+        )
+      );
+    }
+
+    if (
+      !isTitlePage &&
+      (!Array.isArray(translatedBlocks) || translatedBlocks.length === 0)
+    ) {
+      skipNotionPageCreation = true;
+      console.warn(
+        chalk.yellow(
+          `Translated Notion blocks for "${originalTitle}" were empty — skipping Notion page creation to avoid an empty page`
         )
       );
     }
@@ -1597,7 +1666,7 @@ async function processAutomatedTranslation({
     )?.relation?.[0]?.id;
 
   // Notion write (only when not local-only)
-  if (!localOnly) {
+  if (!localOnly && !skipNotionPageCreation) {
     if (parentId) {
       await createNotionPageWithBlocks(
         notion,
@@ -1619,6 +1688,14 @@ async function processAutomatedTranslation({
     }
   }
 
+  const translatedBlocksForDisk =
+    !localOnly &&
+    !skipNotionPageCreation &&
+    Array.isArray(translatedBlocks) &&
+    translatedBlocks.length > 0
+      ? translatedBlocks
+      : undefined;
+
   // Disk write
   await saveAutomatedTranslationToDisk(
     englishPage,
@@ -1626,8 +1703,8 @@ async function processAutomatedTranslation({
     translatedTitle,
     automatedOutputDir,
     undefined, // generate datetime suffix
-    localOnly ? undefined : translatedBlocks,
-    localOnly ? undefined : parentId
+    translatedBlocksForDisk,
+    translatedBlocksForDisk ? parentId : undefined
   );
 
   onNew();

--- a/scripts/notion-translate/index.ts
+++ b/scripts/notion-translate/index.ts
@@ -470,9 +470,9 @@ async function validateAutomatedLanguageOptions(): Promise<void> {
     return;
   }
 
-  if (!DATABASE_ID) {
+  if (!DATABASE_ID && !DATA_SOURCE_ID) {
     console.warn(
-      "Cannot verify automated language select options without DATABASE_ID — ensure they exist in Notion"
+      "Cannot verify automated language select options without DATABASE_ID or DATA_SOURCE_ID — ensure they exist in Notion"
     );
     automatedLanguageOptionsValidated = true;
     return;

--- a/scripts/notion-translate/index.ts
+++ b/scripts/notion-translate/index.ts
@@ -1616,12 +1616,9 @@ async function processAutomatedTranslation({
   // Get automated output directory
   const automatedOutputDir = getAutomatedOutputDir(config.language);
   if (!automatedOutputDir) {
-    console.warn(
-      chalk.yellow(
-        `No automated output dir configured for language: ${config.language} — skipping`
-      )
+    throw new Error(
+      `No automated output dir configured for language: ${config.language}`
     );
-    return;
   }
 
   // Translate content for disk
@@ -1773,7 +1770,7 @@ async function processAutomatedTranslation({
   });
 
   // Disk write
-  await saveAutomatedTranslationToDisk(
+  const writtenPath = await saveAutomatedTranslationToDisk(
     englishPage,
     translatedContent,
     translatedTitle,
@@ -1784,7 +1781,9 @@ async function processAutomatedTranslation({
     properties
   );
 
-  onNew();
+  if (writtenPath) {
+    onNew();
+  }
 }
 
 /**
@@ -2009,6 +2008,7 @@ export function parseCliOptions(args: string[]): CliOptions {
 }
 
 export async function main(options: CliOptions = {}) {
+  automatedLanguageOptionsValidated = false;
   console.log(chalk.bold.cyan("🚀 Starting Notion translation workflow\n"));
 
   // Log which ID type is being used (v5 API validation)

--- a/scripts/notion-translate/index.ts
+++ b/scripts/notion-translate/index.ts
@@ -32,6 +32,7 @@ import { resolveCanonicalDocsRelativePath } from "../notion-fetch/pageMetadataCa
 import {
   replaceCanonicalMarkdownImagesWithPlaceholders,
   decodeLocaleImagePlaceholderPaths,
+  decodeRemoteImagePlaceholderPaths,
   HYPERLINKED_MARKDOWN_IMAGE_REGEX,
   MARKDOWN_IMAGE_REGEX,
   HTML_IMAGE_TAG_REGEX,
@@ -1614,7 +1615,12 @@ async function processAutomatedTranslation({
     translatedContent = translated.markdown;
     translatedTitle = translated.title;
 
-    const { count, samples } = collectRawNotionS3Matches(translatedContent);
+    const decodedTranslatedContent = decodeRemoteImagePlaceholderPaths(
+      decodeLocaleImagePlaceholderPaths(translatedContent)
+    );
+    const { count, samples } = collectRawNotionS3Matches(
+      decodedTranslatedContent
+    );
     if (count > 0) {
       throw new Error(
         `Automated translation for "${originalTitle}" still contains ${count} Notion/S3 URLs. Offending URLs (redacted): ${formatRedactedS3Urls(samples)}`
@@ -1803,8 +1809,11 @@ async function processSinglePageTranslation({
     translatedContent = translated.markdown;
     translatedTitle = translated.title;
 
+    const decodedTranslatedContent = decodeRemoteImagePlaceholderPaths(
+      decodeLocaleImagePlaceholderPaths(translatedContent)
+    );
     const { count: totalS3Matches, samples: detectedS3Urls } =
-      collectRawNotionS3Matches(translatedContent);
+      collectRawNotionS3Matches(decodedTranslatedContent);
 
     if (totalS3Matches > 0) {
       throw new Error(

--- a/scripts/notion-translate/index.ts
+++ b/scripts/notion-translate/index.ts
@@ -491,7 +491,9 @@ async function validateAutomatedLanguageOptions(): Promise<void> {
       ?.map((option) => option.name)
       .filter((name): name is string => Boolean(name)) ?? []
   );
-  const requiredAutomatedOptions = ["PT - automated", "ES - automated"];
+  const requiredAutomatedOptions = LANGUAGES.map((lang) =>
+    getAutomatedLanguageCode(lang.notionLangCode)
+  );
   const missingOptions = requiredAutomatedOptions.filter(
     (optionName) => !optionNames.has(optionName)
   );
@@ -561,7 +563,9 @@ export async function fetchPublishedEnglishPages(
     return englishSourcePages;
   } catch (error) {
     spinner.fail(
-      chalk.red(`Failed to fetch published English pages: ${error.message}`)
+      chalk.red(
+        `Failed to fetch published English pages: ${error instanceof Error ? error.message : String(error)}`
+      )
     );
     throw error;
   }
@@ -1056,7 +1060,8 @@ export async function saveAutomatedTranslationToDisk(
   automatedOutputDir: string,
   datetimeSuffix?: string,
   translatedBlocks?: BlockObjectRequest[],
-  parentId?: string
+  parentId?: string,
+  properties?: Record<string, unknown>
 ): Promise<string> {
   try {
     const elementType = getElementTypeProperty(englishPage);
@@ -1080,7 +1085,8 @@ export async function saveAutomatedTranslationToDisk(
       const day = String(now.getDate()).padStart(2, "0");
       const hours = String(now.getHours()).padStart(2, "0");
       const minutes = String(now.getMinutes()).padStart(2, "0");
-      return `${year}-${month}-${day}T${hours}${minutes}`;
+      const seconds = String(now.getSeconds()).padStart(2, "0");
+      return `${year}-${month}-${day}T${hours}${minutes}${seconds}`;
     })();
 
     const canonicalRelativePath = resolveCanonicalDocsRelativePath(
@@ -1109,11 +1115,37 @@ export async function saveAutomatedTranslationToDisk(
       const sidecarPath = outputPath.endsWith(".md")
         ? outputPath.replace(/\.md$/i, ".notion.json")
         : `${outputPath}.notion.json`;
-      const sidecarData: { parentId?: string; blocks: BlockObjectRequest[] } = {
+      const sidecarData: {
+        parentId?: string;
+        blocks: BlockObjectRequest[];
+        sourceProperties?: Record<string, unknown>;
+      } = {
         blocks: translatedBlocks,
       };
       if (parentId) {
         sidecarData.parentId = parentId;
+      }
+      if (properties) {
+        const { Language: _lang, ...metadataProps } = properties;
+        const normalized: Record<string, unknown> = {};
+        if (NOTION_PROPERTIES.ELEMENT_TYPE in metadataProps) {
+          normalized[NOTION_PROPERTIES.ELEMENT_TYPE] =
+            metadataProps[NOTION_PROPERTIES.ELEMENT_TYPE];
+        } else if (LEGACY_SECTION_PROPERTY in metadataProps) {
+          normalized[NOTION_PROPERTIES.ELEMENT_TYPE] =
+            metadataProps[LEGACY_SECTION_PROPERTY];
+        }
+        for (const key of [
+          NOTION_PROPERTIES.ORDER,
+          NOTION_PROPERTIES.TAGS,
+        ] as const) {
+          if (key in metadataProps) {
+            normalized[key] = metadataProps[key];
+          }
+        }
+        if (Object.keys(normalized).length > 0) {
+          sidecarData.sourceProperties = normalized;
+        }
       }
       await fs.writeFile(
         sidecarPath,
@@ -1634,7 +1666,7 @@ async function processAutomatedTranslation({
   const orderProp = englishPage.properties[NOTION_PROPERTIES.ORDER] as
     | { number?: number }
     | undefined;
-  if (orderProp?.number) {
+  if (typeof orderProp?.number === "number") {
     properties[NOTION_PROPERTIES.ORDER] = { number: orderProp.number };
   }
   const tagsProp = englishPage.properties[NOTION_PROPERTIES.TAGS] as
@@ -1704,7 +1736,8 @@ async function processAutomatedTranslation({
     automatedOutputDir,
     undefined, // generate datetime suffix
     translatedBlocksForDisk,
-    translatedBlocksForDisk ? parentId : undefined
+    translatedBlocksForDisk ? parentId : undefined,
+    properties
   );
 
   onNew();
@@ -1790,7 +1823,7 @@ async function processSinglePageTranslation({
   const orderProp = englishPage.properties[NOTION_PROPERTIES.ORDER] as
     | NotionNumberProperty
     | undefined;
-  if (orderProp && orderProp.number) {
+  if (typeof orderProp?.number === "number") {
     properties[NOTION_PROPERTIES.ORDER] = {
       number: orderProp.number,
     };

--- a/scripts/notion-translate/index.ts
+++ b/scripts/notion-translate/index.ts
@@ -32,7 +32,6 @@ import { resolveCanonicalDocsRelativePath } from "../notion-fetch/pageMetadataCa
 import {
   replaceCanonicalMarkdownImagesWithPlaceholders,
   decodeLocaleImagePlaceholderPaths,
-  decodeRemoteImagePlaceholderPaths,
   HYPERLINKED_MARKDOWN_IMAGE_REGEX,
   MARKDOWN_IMAGE_REGEX,
   HTML_IMAGE_TAG_REGEX,
@@ -1613,6 +1612,13 @@ async function processAutomatedTranslation({
     );
     translatedContent = translated.markdown;
     translatedTitle = translated.title;
+
+    const { count, samples } = collectRawNotionS3Matches(translatedContent);
+    if (count > 0) {
+      throw new Error(
+        `Automated translation for "${originalTitle}" still contains ${count} Notion/S3 URLs. Offending URLs (redacted): ${formatRedactedS3Urls(samples)}`
+      );
+    }
   }
 
   // Translate Notion blocks (only when not local-only)
@@ -1796,10 +1802,8 @@ async function processSinglePageTranslation({
     translatedContent = translated.markdown;
     translatedTitle = translated.title;
 
-    const decodedTranslatedContent =
-      decodeRemoteImagePlaceholderPaths(translatedContent);
     const { count: totalS3Matches, samples: detectedS3Urls } =
-      collectRawNotionS3Matches(decodedTranslatedContent);
+      collectRawNotionS3Matches(translatedContent);
 
     if (totalS3Matches > 0) {
       throw new Error(

--- a/scripts/notion-translate/index.ts
+++ b/scripts/notion-translate/index.ts
@@ -382,7 +382,7 @@ const getOrder = (page: NotionPage): number | undefined =>
     ?.number;
 
 const getParentRelationId = (page: NotionPage): string | undefined => {
-  const parentRelation = page.properties["Parent item"] as
+  const parentRelation = page.properties[PARENT_ITEM_PROPERTY] as
     | NotionRelationProperty
     | undefined;
   return parentRelation?.relation?.[0]?.id;
@@ -1724,12 +1724,12 @@ async function processAutomatedTranslation({
   const parentId =
     relationParentId ??
     (
-      existingTranslationPage?.properties["Parent item"] as
+      existingTranslationPage?.properties[PARENT_ITEM_PROPERTY] as
         | { relation?: Array<{ id: string }> }
         | undefined
     )?.relation?.[0]?.id ??
     (
-      englishPage.properties["Parent item"] as
+      englishPage.properties[PARENT_ITEM_PROPERTY] as
         | { relation?: Array<{ id: string }> }
         | undefined
     )?.relation?.[0]?.id;
@@ -1888,7 +1888,7 @@ async function processSinglePageTranslation({
     const parentInfo =
       relationParentId ??
       (
-        englishPage.properties["Parent item"] as
+        englishPage.properties[PARENT_ITEM_PROPERTY] as
           | NotionRelationProperty
           | undefined
       )?.relation?.[0]?.id;

--- a/scripts/notion-translate/index.ts
+++ b/scripts/notion-translate/index.ts
@@ -1,3 +1,4 @@
+import type { BlockObjectRequest } from "@notionhq/client/build/src/api-endpoints";
 import { pathToFileURL } from "url";
 import dotenv from "dotenv";
 import ora from "ora";
@@ -43,6 +44,8 @@ import {
   NOTION_PROPERTIES,
   NotionPage,
   TranslationConfig,
+  getAutomatedLanguageCode,
+  getAutomatedOutputDir,
 } from "../constants.js";
 
 const LEGACY_SECTION_PROPERTY = "Section";
@@ -321,6 +324,7 @@ type LanguageTranslationSummary = {
   updatedTranslations: number;
   skippedTranslations: number;
   failedTranslations: number;
+  automatedTranslations: number;
   failures: TranslationFailure[];
 };
 
@@ -331,6 +335,7 @@ type TranslationRunSummary = {
   updatedTranslations: number;
   skippedTranslations: number;
   failedTranslations: number;
+  automatedTranslations: number;
   codeJsonFailures: number;
   codeJsonSourceFileMissing: boolean; // Indicates source file was missing/malformed (soft-fail)
   themeFailures: number;
@@ -346,11 +351,15 @@ export interface TranslationUpdateResult {
   needsUpdate: boolean;
   reason?: string;
   blockCount?: number;
+  updateKind?:
+    | "newer-english"
+    | "empty-translation"
+    | "no-translation"
+    | "verification-error";
 }
 
 const getElementTypeProperty = (page: NotionPage) =>
   page.properties?.[NOTION_PROPERTIES.ELEMENT_TYPE] ??
-  // eslint-disable-next-line security/detect-object-injection -- legacy property fallback is static and controlled
   (page.properties as Record<string, any>)?.[LEGACY_SECTION_PROPERTY];
 
 const getTitle = (page: NotionPage): string =>
@@ -376,7 +385,6 @@ const isValidNotionPageId = (pageId: string): boolean =>
   /^[0-9a-f]{32}$/i.test(pageId);
 
 const getSelectedPropertyName = (page: NotionPage, propertyName: string) => {
-  // eslint-disable-next-line security/detect-object-injection -- propertyName is a trusted Notion property constant at each call site
   const property = page.properties?.[propertyName];
   if (!isSelectProperty(property)) {
     return undefined;
@@ -434,7 +442,6 @@ dotenv.config({ override: true, quiet: true });
 function validateRequiredEnvironment(): void {
   const requiredVariables = ["NOTION_API_KEY", "OPENAI_API_KEY"];
   const missingVariables = requiredVariables.filter(
-    // eslint-disable-next-line security/detect-object-injection -- keys come from trusted static array
     (name) => !process.env[name]
   );
   // DATA_SOURCE_ID is the primary variable for Notion API v5 (2025-09-03)
@@ -697,6 +704,7 @@ export async function needsTranslationUpdate(
       needsUpdate: true,
       reason: "No translation exists",
       blockCount: 0,
+      updateKind: "no-translation",
     };
   }
 
@@ -709,6 +717,7 @@ export async function needsTranslationUpdate(
     return {
       needsUpdate: true,
       reason: "English page has newer edits",
+      updateKind: "newer-english",
     };
   }
 
@@ -725,6 +734,7 @@ export async function needsTranslationUpdate(
       needsUpdate,
       reason,
       blockCount,
+      ...(needsUpdate ? { updateKind: "empty-translation" as const } : {}),
     };
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
@@ -736,6 +746,7 @@ export async function needsTranslationUpdate(
     return {
       needsUpdate: true,
       reason: "Unable to verify translation content",
+      updateKind: "verification-error",
     };
   }
 }
@@ -989,6 +1000,89 @@ export async function saveTranslatedContentToDisk(
   }
 }
 
+export async function saveAutomatedTranslationToDisk(
+  englishPage: NotionPage,
+  translatedContent: string,
+  translatedTitle: string,
+  automatedOutputDir: string,
+  datetimeSuffix?: string,
+  translatedBlocks?: BlockObjectRequest[],
+  parentId?: string
+): Promise<string> {
+  try {
+    const elementType = getElementTypeProperty(englishPage);
+    const sectionType = elementType?.select?.name?.toLowerCase();
+    if (sectionType === "toggle") {
+      console.warn(
+        chalk.yellow(
+          `Skipping toggle page \"${getTitle(englishPage)}\" for automated translation output`
+        )
+      );
+      return "";
+    }
+
+    const generatedDatetimeSuffix = (() => {
+      if (datetimeSuffix) {
+        return datetimeSuffix;
+      }
+      const now = new Date();
+      const year = now.getFullYear();
+      const month = String(now.getMonth() + 1).padStart(2, "0");
+      const day = String(now.getDate()).padStart(2, "0");
+      const hours = String(now.getHours()).padStart(2, "0");
+      const minutes = String(now.getMinutes()).padStart(2, "0");
+      return `${year}-${month}-${day}T${hours}${minutes}`;
+    })();
+
+    const canonicalRelativePath = resolveCanonicalDocsRelativePath(
+      englishPage.id
+    );
+
+    const filename = canonicalRelativePath
+      ? `${canonicalRelativePath.replace(/\.md$/i, "")}-${generatedDatetimeSuffix}.md`
+      : `${generateSafeFilename(translatedTitle, englishPage.id)}-${generatedDatetimeSuffix}.md`;
+
+    const outputPath = path.join(automatedOutputDir, filename);
+
+    await fs.mkdir(automatedOutputDir, { recursive: true });
+    await fs.mkdir(path.dirname(outputPath), { recursive: true });
+
+    const localizedContent = await ensureTranslatedFrontmatter(
+      englishPage,
+      decodeLocaleImagePlaceholderPaths(translatedContent),
+      translatedTitle,
+      canonicalRelativePath
+    );
+
+    await fs.writeFile(outputPath, localizedContent, "utf8");
+
+    if (translatedBlocks) {
+      const sidecarPath = outputPath.endsWith(".md")
+        ? outputPath.replace(/\.md$/i, ".notion.json")
+        : `${outputPath}.notion.json`;
+      const sidecarData: { parentId?: string; blocks: BlockObjectRequest[] } = {
+        blocks: translatedBlocks,
+      };
+      if (parentId) {
+        sidecarData.parentId = parentId;
+      }
+      await fs.writeFile(
+        sidecarPath,
+        JSON.stringify(sidecarData, null, 2),
+        "utf8"
+      );
+    }
+
+    return outputPath;
+  } catch (error) {
+    console.error(
+      `Error saving automated translated content for ${englishPage.id}:`,
+      error
+    );
+    throw error;
+  }
+}
+
 /**
  * Translate code.json for all languages except English.
  */
@@ -1155,6 +1249,7 @@ async function processLanguageTranslations(
   let updatedTranslations = 0;
   let skippedTranslations = 0;
   let failedTranslations = 0;
+  let automatedTranslations = 0;
   const failures: TranslationFailure[] = [];
 
   const pagesToProcess = pageId
@@ -1171,13 +1266,12 @@ async function processLanguageTranslations(
     console.log(chalk.blue(`Processing: ${originalTitle}`));
 
     // Pre-flight validation: Check for required Parent item relation
-    /* eslint-disable security/detect-object-injection -- PARENT_ITEM_PROPERTY is a constant */
+
     const parentRelation = (
       englishPage.properties[PARENT_ITEM_PROPERTY] as
         | NotionRelationProperty
         | undefined
     )?.relation?.[0]?.id;
-    /* eslint-enable security/detect-object-injection */
 
     if (!parentRelation && !pageId && !localOnly) {
       console.warn(
@@ -1206,6 +1300,8 @@ async function processLanguageTranslations(
     }
 
     let translationPage: NotionPage | null = null;
+    let automatedPathNeeded = false;
+
     if (!localOnly) {
       translationPage = await findTranslationPage(
         englishPage,
@@ -1229,6 +1325,82 @@ async function processLanguageTranslations(
         skippedTranslations++;
         continue;
       }
+
+      // Route to automated path when translation exists and English is newer
+      if (
+        translationPage !== null &&
+        (updateCheck.updateKind === "newer-english" ||
+          updateCheck.updateKind === "verification-error")
+      ) {
+        automatedPathNeeded = true;
+      }
+    } else {
+      // LOCAL-ONLY: check filesystem for existing translation
+      const canonicalPath = resolveCanonicalDocsRelativePath(englishPage.id);
+      const pathsToCheck: string[] = [];
+      if (canonicalPath) {
+        pathsToCheck.push(path.join(config.outputDir, canonicalPath));
+      } else {
+        const deterministicName = generateSafeFilename(
+          originalTitle,
+          englishPage.id
+        );
+        pathsToCheck.push(
+          path.join(config.outputDir, `${deterministicName}.md`)
+        );
+        console.warn(
+          chalk.yellow(
+            `No canonical path cache for ${englishPage.id}, falling back to deterministic filename probe`
+          )
+        );
+      }
+      for (const existingI18nPath of pathsToCheck) {
+        try {
+          await fs.access(existingI18nPath);
+          automatedPathNeeded = true;
+          console.log(
+            chalk.yellow(
+              `Existing translation found at ${existingI18nPath}, routing to automated path`
+            )
+          );
+          break;
+        } catch {
+          // File doesn't exist → proceed with normal creation
+        }
+      }
+    }
+
+    if (automatedPathNeeded) {
+      try {
+        await processAutomatedTranslation({
+          englishPage,
+          config,
+          existingTranslationPage: translationPage,
+          pageId,
+          localOnly,
+          stabilizedMarkdownCache,
+          relationParentId:
+            parentRelation ?? (pageId ? englishPage.id : undefined),
+          onNew: () => automatedTranslations++,
+        });
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (error instanceof CanonicalPathError) {
+          throw error;
+        }
+        console.error(
+          chalk.red(`Error in automated path for ${originalTitle}:`, message)
+        );
+        failedTranslations++;
+        failures.push({
+          language: config.language,
+          title: originalTitle,
+          pageId: englishPage.id,
+          error: message,
+          isCritical: error instanceof TranslationError && error.isCritical,
+        });
+      }
+      continue;
     }
 
     try {
@@ -1265,6 +1437,9 @@ async function processLanguageTranslations(
   console.log(chalk.green(`\n✅ ${config.language} translation summary:`));
   console.log(chalk.green(`  - New translations: ${newTranslations}`));
   console.log(chalk.green(`  - Updated translations: ${updatedTranslations}`));
+  console.log(
+    chalk.cyan(`  - Automated (no-overwrite): ${automatedTranslations}`)
+  );
   console.log(chalk.gray(`  - Skipped: ${skippedTranslations}`));
   console.log(chalk.red(`  - Failed: ${failedTranslations}`));
 
@@ -1274,8 +1449,188 @@ async function processLanguageTranslations(
     updatedTranslations,
     skippedTranslations,
     failedTranslations,
+    automatedTranslations,
     failures,
   };
+}
+
+/**
+ * Process automated translation — creates a new versioned page/file instead of
+ * overwriting the existing human-reviewed translation.
+ */
+async function processAutomatedTranslation({
+  englishPage,
+  config,
+  existingTranslationPage,
+  pageId,
+  localOnly,
+  stabilizedMarkdownCache,
+  relationParentId,
+  onNew,
+}: {
+  englishPage: NotionPage;
+  config: TranslationConfig;
+  existingTranslationPage: NotionPage | null;
+  pageId?: string;
+  localOnly: boolean;
+  stabilizedMarkdownCache?: Map<string, string>;
+  relationParentId?: string;
+  onNew: () => void;
+}): Promise<void> {
+  const originalTitle = getTitle(englishPage);
+
+  // Skip toggle/category pages
+  const elementType = getElementTypeProperty(englishPage);
+  const sectionType = elementType?.select?.name?.toLowerCase();
+  if (sectionType === "toggle") {
+    console.log(
+      chalk.gray(
+        `Skipping toggle page "${originalTitle}" — automated path does not handle toggles`
+      )
+    );
+    return;
+  }
+
+  // Get automated language code (exactly once — prevents double-apply)
+  const automatedLangCode = getAutomatedLanguageCode(config.notionLangCode);
+
+  // Get automated output directory
+  const automatedOutputDir = getAutomatedOutputDir(config.language);
+  if (!automatedOutputDir) {
+    console.warn(
+      chalk.yellow(
+        `No automated output dir configured for language: ${config.language} — skipping`
+      )
+    );
+    return;
+  }
+
+  // Translate content for disk
+  const isTitlePage = sectionType === "title";
+  let translatedContent: string;
+  let translatedTitle: string;
+
+  if (isTitlePage) {
+    translatedContent = `# ${originalTitle}`;
+    translatedTitle = originalTitle;
+  } else {
+    let markdownContent = stabilizedMarkdownCache?.get(englishPage.id);
+    if (markdownContent === undefined) {
+      markdownContent = await getSourceMarkdownForTranslation(englishPage);
+      stabilizedMarkdownCache?.set(englishPage.id, markdownContent);
+    }
+    const translated = await translateText(
+      markdownContent,
+      originalTitle,
+      config.language
+    );
+    translatedContent = translated.markdown;
+    translatedTitle = translated.title;
+  }
+
+  // Translate Notion blocks (only when not local-only)
+  let translatedBlocks: any[] | undefined;
+  if (!localOnly) {
+    try {
+      if (!isTitlePage) {
+        translatedBlocks = await translateNotionBlocksDirectly(
+          englishPage.id,
+          config.language
+        );
+      } else {
+        translatedBlocks = [
+          {
+            object: "block",
+            type: "heading_1",
+            heading_1: {
+              rich_text: [{ type: "text", text: { content: translatedTitle } }],
+            },
+          },
+        ];
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(
+        chalk.yellow(
+          `Could not translate Notion blocks for "${originalTitle}": ${msg} — Notion page will be created without translated blocks`
+        )
+      );
+    }
+  }
+
+  // Build properties (Language → automated code, plus Order/Tags/ElementType from English)
+  const properties: Record<string, unknown> = {
+    Language: { select: { name: automatedLangCode } },
+  };
+  const orderProp = englishPage.properties[NOTION_PROPERTIES.ORDER] as
+    | { number?: number }
+    | undefined;
+  if (orderProp?.number) {
+    properties[NOTION_PROPERTIES.ORDER] = { number: orderProp.number };
+  }
+  const tagsProp = englishPage.properties[NOTION_PROPERTIES.TAGS] as
+    | { multi_select?: Array<{ name: string }> }
+    | undefined;
+  if (tagsProp?.multi_select) {
+    properties[NOTION_PROPERTIES.TAGS] = {
+      multi_select: tagsProp.multi_select.map((tag) => ({ name: tag.name })),
+    };
+  }
+  if (elementType?.select?.name) {
+    properties[NOTION_PROPERTIES.ELEMENT_TYPE] = {
+      select: { name: elementType.select.name },
+    };
+  }
+
+  // Get parent relation (fallback chain)
+  const parentId =
+    relationParentId ??
+    (
+      existingTranslationPage?.properties["Parent item"] as
+        | { relation?: Array<{ id: string }> }
+        | undefined
+    )?.relation?.[0]?.id ??
+    (
+      englishPage.properties["Parent item"] as
+        | { relation?: Array<{ id: string }> }
+        | undefined
+    )?.relation?.[0]?.id;
+
+  // Notion write (only when not local-only)
+  if (!localOnly) {
+    if (parentId) {
+      await createNotionPageWithBlocks(
+        notion,
+        parentId,
+        DATA_SOURCE_ID || DATABASE_ID,
+        translatedTitle,
+        translatedBlocks ?? [],
+        properties,
+        automatedLangCode,
+        undefined, // no existingPageId — always create new
+        true // forceCreate — skip DB search entirely
+      );
+    } else {
+      console.warn(
+        chalk.yellow(
+          `Cannot determine parent relation for "${originalTitle}" (${englishPage.id}) — skipping Notion write`
+        )
+      );
+    }
+  }
+
+  // Disk write
+  await saveAutomatedTranslationToDisk(
+    englishPage,
+    translatedContent,
+    translatedTitle,
+    automatedOutputDir,
+    undefined, // generate datetime suffix
+    localOnly ? undefined : translatedBlocks,
+    localOnly ? undefined : parentId
+  );
+
+  onNew();
 }
 
 /**
@@ -1458,7 +1813,6 @@ export function parseCliOptions(args: string[]): CliOptions {
   const options: CliOptions = {};
 
   for (let i = 0; i < args.length; i++) {
-    // eslint-disable-next-line security/detect-object-injection -- iterating over trusted CLI args array
     const arg = args[i];
     if (arg === "--page-id") {
       const value = args[i + 1];
@@ -1521,6 +1875,7 @@ export async function main(options: CliOptions = {}) {
     updatedTranslations: 0,
     skippedTranslations: 0,
     failedTranslations: 0,
+    automatedTranslations: 0,
     codeJsonFailures: 0,
     codeJsonSourceFileMissing: false,
     themeFailures: 0,
@@ -1662,6 +2017,7 @@ export async function main(options: CliOptions = {}) {
       summary.updatedTranslations += languageSummary.updatedTranslations;
       summary.skippedTranslations += languageSummary.skippedTranslations;
       summary.failedTranslations += languageSummary.failedTranslations;
+      summary.automatedTranslations += languageSummary.automatedTranslations;
       failures.push(...languageSummary.failures);
     }
 

--- a/scripts/notion-translate/index.ts
+++ b/scripts/notion-translate/index.ts
@@ -1165,6 +1165,30 @@ export async function saveAutomatedTranslationToDisk(
   }
 }
 
+export function getTranslatedBlocksForDisk({
+  localOnly,
+  skipNotionPageCreation,
+  translatedBlocks,
+  parentId,
+}: {
+  localOnly: boolean;
+  skipNotionPageCreation: boolean;
+  translatedBlocks: BlockObjectRequest[] | undefined;
+  parentId?: string;
+}): BlockObjectRequest[] | undefined {
+  if (
+    localOnly ||
+    skipNotionPageCreation ||
+    !parentId ||
+    !Array.isArray(translatedBlocks) ||
+    translatedBlocks.length === 0
+  ) {
+    return undefined;
+  }
+
+  return translatedBlocks;
+}
+
 /**
  * Translate code.json for all languages except English.
  */
@@ -1725,6 +1749,7 @@ async function processAutomatedTranslation({
         true // forceCreate — skip DB search entirely
       );
     } else {
+      skipNotionPageCreation = true;
       console.warn(
         chalk.yellow(
           `Cannot determine parent relation for "${originalTitle}" (${englishPage.id}) — skipping Notion write`
@@ -1733,13 +1758,12 @@ async function processAutomatedTranslation({
     }
   }
 
-  const translatedBlocksForDisk =
-    !localOnly &&
-    !skipNotionPageCreation &&
-    Array.isArray(translatedBlocks) &&
-    translatedBlocks.length > 0
-      ? translatedBlocks
-      : undefined;
+  const translatedBlocksForDisk = getTranslatedBlocksForDisk({
+    localOnly,
+    skipNotionPageCreation,
+    translatedBlocks,
+    parentId,
+  });
 
   // Disk write
   await saveAutomatedTranslationToDisk(

--- a/scripts/notion-translate/index.ts
+++ b/scripts/notion-translate/index.ts
@@ -478,12 +478,19 @@ async function validateAutomatedLanguageOptions(): Promise<void> {
     return;
   }
 
-  const database = (await notion.databases.retrieve({
-    database_id: DATABASE_ID,
-  })) as {
-    properties?: Record<string, unknown>;
-  };
-  const languageProperty = database.properties?.[NOTION_PROPERTIES.LANGUAGE] as
+  const useActiveDataSource = DATA_SOURCE_ID && DATA_SOURCE_ID !== DATABASE_ID;
+  const source = useActiveDataSource
+    ? ((await notion.dataSources.retrieve({
+        data_source_id: DATA_SOURCE_ID,
+      })) as {
+        properties?: Record<string, unknown>;
+      })
+    : ((await notion.databases.retrieve({
+        database_id: DATABASE_ID,
+      })) as {
+        properties?: Record<string, unknown>;
+      });
+  const languageProperty = source.properties?.[NOTION_PROPERTIES.LANGUAGE] as
     | NotionDatabaseSelectSchemaProperty
     | undefined;
   const optionNames = new Set(

--- a/scripts/notion-translate/translateBlocks.test.ts
+++ b/scripts/notion-translate/translateBlocks.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Client } from "@notionhq/client";
 
 const mockBlocksChildrenList = vi.fn();
 const mockTranslateText = vi.fn();
@@ -15,6 +16,22 @@ vi.mock("./translateFrontMatter.js", () => ({
 
 function blocksResponse(results: object[]) {
   return { results, has_more: false, next_cursor: null };
+}
+
+function createMockNotionClient() {
+  return {
+    pages: {
+      create: vi.fn(),
+      update: vi.fn(),
+    },
+    blocks: {
+      children: {
+        list: vi.fn(),
+        append: vi.fn(),
+      },
+      delete: vi.fn(),
+    },
+  } as unknown as Client;
 }
 
 describe("translateNotionBlocksDirectly", () => {
@@ -212,5 +229,120 @@ describe("translateNotionBlocksDirectly", () => {
     expect(block.parent).toBeUndefined();
     expect(block.archived).toBeUndefined();
     expect(block.type).toBe("paragraph");
+  });
+
+  it("reuses the same created page on retry when append fails once", async () => {
+    const notion = createMockNotionClient();
+    const mockPageId = "page-created-once";
+
+    vi.mocked(notion.pages.create).mockResolvedValue({
+      id: mockPageId,
+    } as never);
+    vi.mocked(notion.pages.update).mockResolvedValue({} as never);
+    vi.mocked(notion.blocks.children.list).mockResolvedValueOnce(
+      blocksResponse([
+        {
+          id: "stale-block-id",
+        },
+      ]) as never
+    );
+    vi.mocked(notion.blocks.children.append)
+      .mockRejectedValueOnce(new Error("append failed once"))
+      .mockResolvedValueOnce({} as never);
+    vi.mocked(notion.blocks.delete).mockResolvedValue({} as never);
+
+    const { createNotionPageWithBlocks } = await import("./translateBlocks");
+    const pageId = await createNotionPageWithBlocks(
+      notion,
+      "parent-page-id",
+      "database-id",
+      "Translated page",
+      [
+        {
+          type: "paragraph",
+          paragraph: {
+            rich_text: [
+              {
+                type: "text",
+                text: { content: "Block content" },
+              },
+            ],
+          },
+        },
+      ],
+      {},
+      "pt-BR",
+      undefined,
+      true
+    );
+
+    expect(pageId).toBe(mockPageId);
+    expect(notion.pages.create).toHaveBeenCalledTimes(1);
+    expect(notion.pages.update).toHaveBeenCalledTimes(1);
+    expect(notion.pages.update).toHaveBeenCalledWith({
+      page_id: mockPageId,
+      properties: expect.objectContaining({
+        "Content elements": {
+          title: [{ text: { content: "Translated page" } }],
+        },
+      }),
+    });
+    expect(notion.blocks.children.list).toHaveBeenCalledTimes(1);
+    expect(notion.blocks.delete).toHaveBeenCalledTimes(1);
+    expect(notion.blocks.delete).toHaveBeenCalledWith({
+      block_id: "stale-block-id",
+    });
+    expect(notion.blocks.children.append).toHaveBeenCalledTimes(2);
+    expect(notion.blocks.children.append).toHaveBeenNthCalledWith(1, {
+      block_id: mockPageId,
+      children: expect.any(Array),
+    });
+    expect(notion.blocks.children.append).toHaveBeenNthCalledWith(2, {
+      block_id: mockPageId,
+      children: expect.any(Array),
+    });
+  });
+
+  it("still creates a new page when forceCreate is true even if existingPageId is provided", async () => {
+    const notion = createMockNotionClient();
+
+    vi.mocked(notion.pages.create).mockResolvedValue({
+      id: "new-force-created-page",
+    } as never);
+    vi.mocked(notion.blocks.children.append).mockResolvedValue({} as never);
+
+    const { createNotionPageWithBlocks } = await import("./translateBlocks");
+    const pageId = await createNotionPageWithBlocks(
+      notion,
+      "parent-page-id",
+      "database-id",
+      "Translated page",
+      [
+        {
+          type: "paragraph",
+          paragraph: {
+            rich_text: [
+              {
+                type: "text",
+                text: { content: "Block content" },
+              },
+            ],
+          },
+        },
+      ],
+      {},
+      "pt-BR",
+      "existing-page-id",
+      true
+    );
+
+    expect(pageId).toBe("new-force-created-page");
+    expect(notion.pages.create).toHaveBeenCalledTimes(1);
+    expect(notion.pages.update).not.toHaveBeenCalled();
+    expect(notion.blocks.children.list).not.toHaveBeenCalled();
+    expect(notion.blocks.children.append).toHaveBeenCalledWith({
+      block_id: "new-force-created-page",
+      children: expect.any(Array),
+    });
   });
 });

--- a/scripts/notion-translate/translateBlocks.ts
+++ b/scripts/notion-translate/translateBlocks.ts
@@ -342,6 +342,7 @@ export async function createNotionPageWithBlocks(
 
         if (nonEnglishResults.length > 0) {
           pageId = nonEnglishResults[0].id;
+          retryPageId = pageId;
         }
       }
 

--- a/scripts/notion-translate/translateBlocks.ts
+++ b/scripts/notion-translate/translateBlocks.ts
@@ -206,7 +206,7 @@ async function translateBlocksTree(
     }
 
     const blockType = newBlock.type as string;
-    // eslint-disable-next-line security/detect-object-injection -- blockType comes from Notion API block.type, not user input
+
     const typeObj = newBlock[blockType] as
       | (Record<string, unknown> & {
           url?: string;
@@ -251,7 +251,6 @@ async function translateBlocksTree(
     }
 
     if (block.children) {
-      // eslint-disable-next-line security/detect-object-injection -- blockType comes from Notion API block.type, not user input
       const parentTypeObj = newBlock[blockType] as Record<string, unknown>;
       parentTypeObj.children = await translateBlocksTree(
         block.children,
@@ -272,7 +271,8 @@ export async function createNotionPageWithBlocks(
   blocks: BlockObjectRequest[],
   properties: Record<string, unknown> = {},
   language?: string,
-  existingPageId?: string
+  existingPageId?: string,
+  forceCreate?: boolean
 ): Promise<string> {
   const MAX_RETRIES = 3;
   const NOTION_API_CHUNK_SIZE = 100;
@@ -285,48 +285,59 @@ export async function createNotionPageWithBlocks(
         throw new Error("Cannot modify English pages");
       }
 
-      let pageId: string | null = existingPageId ?? null;
+      let pageId: string | null = null;
       const pageRelation = {
         "Parent item": {
           relation: [{ id: parentPageId }],
         },
       };
 
-      if (!existingPageId) {
-        const filter = language
-          ? {
-              and: [
-                { property: NOTION_PROPERTIES.TITLE, title: { equals: title } },
-                {
-                  property: NOTION_PROPERTIES.LANGUAGE,
-                  select: { equals: language },
-                },
-              ],
-            }
-          : { property: NOTION_PROPERTIES.TITLE, title: { equals: title } };
+      // When forceCreate is set, skip the DB search entirely and always create
+      if (!forceCreate) {
+        pageId = existingPageId ?? null;
 
-        const response = await enhancedNotion.dataSourcesQuery({
-          data_source_id: databaseId,
-          filter: filter,
-        });
-
-        const nonEnglishResults = language
-          ? response.results
-          : response.results.filter(
-              (page: {
-                properties?: Record<string, unknown>;
-                [k: string]: unknown;
-              }) => {
-                const langProp = page.properties?.[
-                  NOTION_PROPERTIES.LANGUAGE
-                ] as { select?: { name?: string } } | undefined;
-                const pageLang = langProp?.select?.name || "en";
-                return pageLang !== "en";
+        if (!existingPageId) {
+          const filter = language
+            ? {
+                and: [
+                  {
+                    property: NOTION_PROPERTIES.TITLE,
+                    title: { equals: title },
+                  },
+                  {
+                    property: NOTION_PROPERTIES.LANGUAGE,
+                    select: { equals: language },
+                  },
+                ],
               }
-            );
+            : {
+                property: NOTION_PROPERTIES.TITLE,
+                title: { equals: title },
+              };
 
-        if (nonEnglishResults.length > 0) {
-          pageId = nonEnglishResults[0].id;
+          const response = await enhancedNotion.dataSourcesQuery({
+            data_source_id: databaseId,
+            filter: filter,
+          });
+
+          const nonEnglishResults = language
+            ? response.results
+            : response.results.filter(
+                (page: {
+                  properties?: Record<string, unknown>;
+                  [k: string]: unknown;
+                }) => {
+                  const langProp = page.properties?.[
+                    NOTION_PROPERTIES.LANGUAGE
+                  ] as { select?: { name?: string } } | undefined;
+                  const pageLang = langProp?.select?.name || "en";
+                  return pageLang !== "en";
+                }
+              );
+
+          if (nonEnglishResults.length > 0) {
+            pageId = nonEnglishResults[0].id;
+          }
         }
       }
 

--- a/scripts/notion-translate/translateBlocks.ts
+++ b/scripts/notion-translate/translateBlocks.ts
@@ -171,6 +171,9 @@ async function translateBlocksTree(
     delete newBlock.archived;
     delete newBlock.in_trash;
     delete newBlock.children;
+    // Remove read-only/metadata fields that Notion rejects on block creation
+    delete newBlock.object;
+    delete newBlock.icon;
 
     if (
       newBlock.type === "child_page" ||
@@ -244,9 +247,10 @@ async function translateBlocksTree(
         }
       }
 
-      // Clean up unsupported properties that Notion API rejects on creation
-      if (blockType === "table" && typeObj.table_width !== undefined) {
-        // sometimes table_width is read-only? No, table_width is required.
+      // Clean up unsupported properties that Notion API rejects on block creation.
+      // The Notion API returns these fields when reading but rejects them as null on write.
+      if ("icon" in typeObj && typeObj.icon === null) {
+        delete typeObj.icon;
       }
     }
 

--- a/scripts/notion-translate/translateBlocks.ts
+++ b/scripts/notion-translate/translateBlocks.ts
@@ -282,6 +282,9 @@ export async function createNotionPageWithBlocks(
   const NOTION_API_CHUNK_SIZE = 100;
   let retryCount = 0;
   let lastError: Error | null = null;
+  let retryPageId: string | null = forceCreate
+    ? null
+    : (existingPageId ?? null);
 
   while (retryCount < MAX_RETRIES) {
     try {
@@ -289,7 +292,8 @@ export async function createNotionPageWithBlocks(
         throw new Error("Cannot modify English pages");
       }
 
-      let pageId: string | null = null;
+      let pageId = retryPageId;
+
       const pageRelation = {
         "Parent item": {
           relation: [{ id: parentPageId }],
@@ -297,51 +301,47 @@ export async function createNotionPageWithBlocks(
       };
 
       // When forceCreate is set, skip the DB search entirely and always create
-      if (!forceCreate) {
-        pageId = existingPageId ?? null;
+      if (!forceCreate && !pageId) {
+        const filter = language
+          ? {
+              and: [
+                {
+                  property: NOTION_PROPERTIES.TITLE,
+                  title: { equals: title },
+                },
+                {
+                  property: NOTION_PROPERTIES.LANGUAGE,
+                  select: { equals: language },
+                },
+              ],
+            }
+          : {
+              property: NOTION_PROPERTIES.TITLE,
+              title: { equals: title },
+            };
 
-        if (!existingPageId) {
-          const filter = language
-            ? {
-                and: [
-                  {
-                    property: NOTION_PROPERTIES.TITLE,
-                    title: { equals: title },
-                  },
-                  {
-                    property: NOTION_PROPERTIES.LANGUAGE,
-                    select: { equals: language },
-                  },
-                ],
+        const response = await enhancedNotion.dataSourcesQuery({
+          data_source_id: databaseId,
+          filter: filter,
+        });
+
+        const nonEnglishResults = language
+          ? response.results
+          : response.results.filter(
+              (page: {
+                properties?: Record<string, unknown>;
+                [k: string]: unknown;
+              }) => {
+                const langProp = page.properties?.[
+                  NOTION_PROPERTIES.LANGUAGE
+                ] as { select?: { name?: string } } | undefined;
+                const pageLang = langProp?.select?.name || "en";
+                return pageLang !== "en";
               }
-            : {
-                property: NOTION_PROPERTIES.TITLE,
-                title: { equals: title },
-              };
+            );
 
-          const response = await enhancedNotion.dataSourcesQuery({
-            data_source_id: databaseId,
-            filter: filter,
-          });
-
-          const nonEnglishResults = language
-            ? response.results
-            : response.results.filter(
-                (page: {
-                  properties?: Record<string, unknown>;
-                  [k: string]: unknown;
-                }) => {
-                  const langProp = page.properties?.[
-                    NOTION_PROPERTIES.LANGUAGE
-                  ] as { select?: { name?: string } } | undefined;
-                  const pageLang = langProp?.select?.name || "en";
-                  return pageLang !== "en";
-                }
-              );
-
-          if (nonEnglishResults.length > 0) {
-            pageId = nonEnglishResults[0].id;
-          }
+        if (nonEnglishResults.length > 0) {
+          pageId = nonEnglishResults[0].id;
         }
       }
 
@@ -390,6 +390,7 @@ export async function createNotionPageWithBlocks(
           properties: pageProperties,
         });
         pageId = newPage.id;
+        retryPageId = pageId;
       }
 
       // Add content blocks in chunks to avoid API limits

--- a/scripts/notionClient.ts
+++ b/scripts/notionClient.ts
@@ -28,13 +28,18 @@ if (!process.env.NOTION_API_KEY) {
 }
 
 const resolvedDatabaseId =
-  process.env.DATABASE_ID ?? process.env.NOTION_DATABASE_ID;
+  process.env.DATABASE_ID ?? process.env.NOTION_DATABASE_ID ?? "";
+const rawDataSourceId = process.env.DATA_SOURCE_ID;
 
-if (!resolvedDatabaseId) {
-  throw new Error("DATABASE_ID is not defined in the environment variables.");
+if (!resolvedDatabaseId && !rawDataSourceId) {
+  throw new Error(
+    "DATABASE_ID (or DATA_SOURCE_ID) is not defined in the environment variables."
+  );
 }
 
-process.env.DATABASE_ID = resolvedDatabaseId;
+if (resolvedDatabaseId) {
+  process.env.DATABASE_ID = resolvedDatabaseId;
+}
 
 // Configuration for retry logic
 // Standardized test environment detection
@@ -437,13 +442,11 @@ const imageTransformer: BlockToMarkdown = async (block) => {
 
 n2m.setCustomTransformer("image", imageTransformer);
 
-export const DATABASE_ID = resolvedDatabaseId;
+export const DATABASE_ID = resolvedDatabaseId || undefined;
 
 // For v5 API compatibility - export data source ID
 // DATA_SOURCE_ID is required for v5 API. If not set, warn and fall back to DATABASE_ID
 // Note: DATABASE_ID and DATA_SOURCE_ID may be different values in v5!
-const rawDataSourceId = process.env.DATA_SOURCE_ID;
-
 if (!rawDataSourceId && !IS_TEST_ENV) {
   console.warn(
     chalk.yellow(
@@ -489,7 +492,7 @@ export const getActiveDataSourceId = (): string => {
 };
 
 // Export the active database ID based on test mode
-export const getActiveDatabaseId = (): string => {
+export const getActiveDatabaseId = (): string | undefined => {
   if (isTestMode && TEST_DATABASE_ID) {
     return TEST_DATABASE_ID;
   }

--- a/scripts/push-new-translation-to-notion.test.ts
+++ b/scripts/push-new-translation-to-notion.test.ts
@@ -4,8 +4,9 @@
  * Verifies that the push CLI correctly reads sourceProperties from the
  * .notion.json sidecar and passes them through to createNotionPageWithBlocks.
  *
- * Strategy: Since the push CLI auto-executes on import, we use vi.resetModules()
- * with vi.doMock() to re-import the module for each test case with fresh state.
+ * Strategy: The module exports run(), so tests call it directly with an args
+ * override. Top-level execution is guarded by import.meta.main, so no module
+ * cache reset is needed between test cases.
  */
 import fs from "node:fs/promises";
 import path from "node:path";
@@ -58,37 +59,15 @@ async function runPushCli(
   await fs.writeFile(mdPath, mdContent, "utf8");
   await fs.writeFile(sidecarPath, JSON.stringify(sidecarData, null, 2), "utf8");
 
-  const originalArgv = process.argv;
   const originalEnv = { ...process.env };
-  process.argv = [
-    "bun",
-    "scripts/push-new-translation-to-notion.ts",
-    "--file",
-    mdPath,
-    "--language",
-    language,
-  ];
   process.env.DATA_SOURCE_ID = "test-ds-id";
   process.env.DATABASE_ID = "test-db-id";
 
-  // Invalidate module cache to get a fresh import
-  vi.resetModules();
-  // Re-mock after resetModules
-  vi.doMock("./notion-translate/translateBlocks.js", () => ({
-    createNotionPageWithBlocks: mockCreateNotionPageWithBlocks,
-  }));
-  vi.doMock("./notionClient.js", () => ({
-    notion: {},
-  }));
-  vi.doMock("dotenv", () => ({
-    default: { config: vi.fn() },
-  }));
-
   mockCreateNotionPageWithBlocks.mockResolvedValue("new-page-id");
 
-  await import("./push-new-translation-to-notion");
+  const { run } = await import("./push-new-translation-to-notion.js");
+  await run(["--file", mdPath, "--language", language]);
 
-  process.argv = originalArgv;
   process.env = originalEnv;
 
   expect(mockCreateNotionPageWithBlocks).toHaveBeenCalledTimes(1);

--- a/scripts/push-new-translation-to-notion.test.ts
+++ b/scripts/push-new-translation-to-notion.test.ts
@@ -1,0 +1,204 @@
+/**
+ * Tests for push-new-translation-to-notion.ts — property handling
+ *
+ * Verifies that the push CLI correctly reads sourceProperties from the
+ * .notion.json sidecar and passes them through to createNotionPageWithBlocks.
+ *
+ * Strategy: Since the push CLI auto-executes on import, we use vi.resetModules()
+ * with vi.doMock() to re-import the module for each test case with fresh state.
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import os from "node:os";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before any imports that trigger module resolution
+// ---------------------------------------------------------------------------
+
+const mockCreateNotionPageWithBlocks = vi.fn();
+
+vi.mock("./notion-translate/translateBlocks.js", () => ({
+  createNotionPageWithBlocks: mockCreateNotionPageWithBlocks,
+}));
+
+vi.mock("./notionClient.js", () => ({
+  notion: {},
+}));
+
+vi.mock("dotenv", () => ({
+  default: { config: vi.fn() },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function createTempDir(): Promise<string> {
+  const dir = path.join(
+    os.tmpdir(),
+    `push-translation-test-${Date.now()}-${Math.random().toString(36).slice(2)}`
+  );
+  await fs.mkdir(dir, { recursive: true });
+  return dir;
+}
+
+/**
+ * Run the push CLI with the given sidecar data and language.
+ * Creates temp .md + .notion.json files, sets up argv, imports the module.
+ */
+async function runPushCli(
+  sidecarData: Record<string, unknown>,
+  language: string,
+  mdContent = "---\ntitle: Test Page\n---\n\nSome content"
+): Promise<Record<string, unknown>> {
+  const tempDir = await createTempDir();
+  const mdPath = path.join(tempDir, "test-page.md");
+  const sidecarPath = path.join(tempDir, "test-page.notion.json");
+  await fs.writeFile(mdPath, mdContent, "utf8");
+  await fs.writeFile(sidecarPath, JSON.stringify(sidecarData, null, 2), "utf8");
+
+  const originalArgv = process.argv;
+  const originalEnv = { ...process.env };
+  process.argv = [
+    "bun",
+    "scripts/push-new-translation-to-notion.ts",
+    "--file",
+    mdPath,
+    "--language",
+    language,
+  ];
+  process.env.DATA_SOURCE_ID = "test-ds-id";
+  process.env.DATABASE_ID = "test-db-id";
+
+  // Invalidate module cache to get a fresh import
+  vi.resetModules();
+  // Re-mock after resetModules
+  vi.doMock("./notion-translate/translateBlocks.js", () => ({
+    createNotionPageWithBlocks: mockCreateNotionPageWithBlocks,
+  }));
+  vi.doMock("./notionClient.js", () => ({
+    notion: {},
+  }));
+  vi.doMock("dotenv", () => ({
+    default: { config: vi.fn() },
+  }));
+
+  mockCreateNotionPageWithBlocks.mockResolvedValue("new-page-id");
+
+  await import("./push-new-translation-to-notion");
+
+  process.argv = originalArgv;
+  process.env = originalEnv;
+
+  expect(mockCreateNotionPageWithBlocks).toHaveBeenCalledTimes(1);
+  const properties = mockCreateNotionPageWithBlocks.mock.calls[0][5] as Record<
+    string,
+    unknown
+  >;
+
+  // Clean up temp dir (after assertions so the CLI's catch handler doesn't fire)
+  await fs.rm(tempDir, { recursive: true, force: true }).catch(() => {});
+
+  return properties;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("push-new-translation-to-notion property handling", () => {
+  let exitSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockCreateNotionPageWithBlocks.mockReset();
+    // Suppress process.exit calls from the CLI's catch handler
+    exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+  });
+
+  afterEach(() => {
+    exitSpy.mockRestore();
+  });
+
+  it("passes sourceProperties through to createNotionPageWithBlocks", async () => {
+    const properties = await runPushCli(
+      {
+        parentId: "parent-123",
+        blocks: [{ type: "paragraph", paragraph: { rich_text: [] } }],
+        sourceProperties: {
+          "Element Type": { select: { name: "Page" } },
+          Order: { number: 7 },
+          Tags: { multi_select: [{ name: "guide" }] },
+        },
+      },
+      "PT - automated"
+    );
+
+    expect(properties["Element Type"]).toEqual({ select: { name: "Page" } });
+    expect(properties["Order"]).toEqual({ number: 7 });
+    expect(properties["Tags"]).toEqual({
+      multi_select: [{ name: "guide" }],
+    });
+    expect(properties["Language"]).toEqual({
+      select: { name: "PT - automated" },
+    });
+  });
+
+  it("works with legacy sidecar without sourceProperties (backward compat)", async () => {
+    const properties = await runPushCli(
+      {
+        parentId: "parent-legacy",
+        blocks: [{ type: "paragraph", paragraph: { rich_text: [] } }],
+      },
+      "ES - automated"
+    );
+
+    expect(Object.keys(properties)).toEqual(["Language"]);
+    expect(properties["Language"]).toEqual({
+      select: { name: "ES - automated" },
+    });
+  });
+
+  it("Language from --language arg always wins over sourceProperties", async () => {
+    const properties = await runPushCli(
+      {
+        parentId: "parent-conflict",
+        blocks: [],
+        sourceProperties: {
+          // Stale Language that should be overridden
+          Language: { select: { name: "PT - automated" } },
+          "Element Type": { select: { name: "Heading" } },
+        },
+      },
+      "ES - automated"
+    );
+
+    // CLI --language must win
+    expect(properties["Language"]).toEqual({
+      select: { name: "ES - automated" },
+    });
+    // sourceProperties still passed through
+    expect(properties["Element Type"]).toEqual({ select: { name: "Heading" } });
+  });
+
+  it("includes only present sourceProperties fields when some are missing", async () => {
+    const properties = await runPushCli(
+      {
+        parentId: "parent-partial",
+        blocks: [],
+        sourceProperties: {
+          "Element Type": { select: { name: "Toggle" } },
+          // No Order, no Tags
+        },
+      },
+      "PT - automated"
+    );
+
+    expect(properties["Element Type"]).toEqual({ select: { name: "Toggle" } });
+    expect(properties["Order"]).toBeUndefined();
+    expect(properties["Tags"]).toBeUndefined();
+    expect(properties["Language"]).toEqual({
+      select: { name: "PT - automated" },
+    });
+  });
+});

--- a/scripts/push-new-translation-to-notion.test.ts
+++ b/scripts/push-new-translation-to-notion.test.ts
@@ -86,6 +86,27 @@ async function runPushCli(
 // Tests
 // ---------------------------------------------------------------------------
 
+describe("parseSimpleFrontmatter — closing delimiter detection", () => {
+  it("does not truncate YAML when a value contains ---", async () => {
+    // Regression: indexOf('---', 3) would match the '---' inside the title value
+    const mdContent =
+      "---\ntitle: Hello --- World\nauthor: test\n---\n\nBody text";
+    const properties = await runPushCli(
+      {
+        parentId: "parent-regression",
+        blocks: [],
+      },
+      "PT - automated",
+      mdContent
+    );
+    // The title read by run() is not exposed via properties, but if frontmatter
+    // parsed correctly the CLI completes without error and Language is set.
+    expect(properties["Language"]).toEqual({
+      select: { name: "PT - automated" },
+    });
+  });
+});
+
 describe("push-new-translation-to-notion property handling", () => {
   let exitSpy: ReturnType<typeof vi.spyOn>;
 

--- a/scripts/push-new-translation-to-notion.ts
+++ b/scripts/push-new-translation-to-notion.ts
@@ -1,0 +1,153 @@
+#!/usr/bin/env bun
+/**
+ * Push a pre-translated automated translation file to Notion as a new page.
+ *
+ * Usage:
+ *   bun scripts/push-new-translation-to-notion.ts --file <path> --language <"PT - automated"|"ES - automated">
+ *
+ * Requires: the file to have a corresponding .notion.json sidecar from a Notion-API translation run.
+ * Does NOT work with files generated in --local-only mode (no sidecar).
+ */
+import fs from "node:fs/promises";
+import path from "node:path";
+import dotenv from "dotenv";
+import { createNotionPageWithBlocks } from "./notion-translate/translateBlocks.js";
+import { notion } from "./notionClient.js";
+
+dotenv.config({ override: true });
+
+const DATA_SOURCE_ID = process.env.DATA_SOURCE_ID ?? "";
+const DATABASE_ID = process.env.DATABASE_ID ?? "";
+
+/** Minimal frontmatter parser — splits on --- delimiters and parses key: value pairs. */
+function parseSimpleFrontmatter(content: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  const trimmed = content.trimStart();
+
+  if (!trimmed.startsWith("---")) return result;
+
+  const closingIndex = trimmed.indexOf("---", 3);
+  if (closingIndex === -1) return result;
+
+  const yaml = trimmed.slice(3, closingIndex).trim();
+
+  for (const line of yaml.split("\n")) {
+    const colonIndex = line.indexOf(":");
+    if (colonIndex === -1) continue;
+    const key = line.slice(0, colonIndex).trim();
+    const value = line
+      .slice(colonIndex + 1)
+      .trim()
+      .replace(/^['"]|['"]$/g, "");
+    if (key) {
+      // eslint-disable-next-line security/detect-object-injection -- key comes from frontmatter line parsing, not user input
+      result[key] = value;
+    }
+  }
+
+  return result;
+}
+
+function parseArgs(): { file: string; language: string } {
+  const args = process.argv.slice(2);
+  const fileIndex = args.indexOf("--file");
+  const languageIndex = args.indexOf("--language");
+
+  if (fileIndex === -1 || !args[fileIndex + 1]) {
+    throw new Error("Missing --file argument");
+  }
+  if (languageIndex === -1 || !args[languageIndex + 1]) {
+    throw new Error(
+      "Missing --language argument. Expected: 'PT - automated' or 'ES - automated'"
+    );
+  }
+
+  const language = args[languageIndex + 1];
+  if (language !== "PT - automated" && language !== "ES - automated") {
+    throw new Error(
+      `Invalid --language value: "${language}". Expected: 'PT - automated' or 'ES - automated'`
+    );
+  }
+
+  return { file: args[fileIndex + 1], language };
+}
+
+async function run() {
+  const { file, language } = parseArgs();
+
+  const filePath = path.resolve(file);
+  const sidecarPath = filePath.replace(/\.md$/i, ".notion.json");
+
+  console.log(`File: ${filePath}`);
+  console.log(`Language: ${language}`);
+
+  // Check sidecar exists
+  try {
+    await fs.access(sidecarPath);
+  } catch {
+    throw new Error(
+      `No .notion.json sidecar found at ${sidecarPath}. ` +
+        `Run the translation with Notion API access (without --local-only) to generate block data.`
+    );
+  }
+
+  // Read markdown file for title
+  const markdownContent = await fs.readFile(filePath, "utf8");
+  const frontmatter = parseSimpleFrontmatter(markdownContent);
+  const title = frontmatter.title ?? path.basename(filePath, ".md");
+
+  // Read Notion blocks sidecar (contains parentId + blocks)
+  const sidecarContent = await fs.readFile(sidecarPath, "utf8");
+  const sidecarParsed: unknown = JSON.parse(sidecarContent);
+  const sidecar = sidecarParsed as {
+    parentId?: string;
+    blocks?: unknown[];
+  };
+
+  // Support both wrapped format { parentId, blocks } and legacy bare array
+  const blocks = (
+    Array.isArray(sidecarParsed) ? sidecarParsed : (sidecar.blocks ?? [])
+  ) as import("@notionhq/client/build/src/api-endpoints").BlockObjectRequest[];
+  const parentId = !Array.isArray(sidecarParsed) ? sidecar.parentId : undefined;
+
+  if (!parentId) {
+    throw new Error(
+      `No parentId found in sidecar ${sidecarPath}. ` +
+        `Re-run the translation (without --local-only) to regenerate the sidecar with parent metadata.`
+    );
+  }
+
+  const databaseId = DATA_SOURCE_ID || DATABASE_ID;
+  if (!databaseId) {
+    throw new Error(
+      "Neither DATA_SOURCE_ID nor DATABASE_ID environment variable is set"
+    );
+  }
+
+  console.log(`Creating Notion page: "${title}" under parent ${parentId}`);
+
+  const properties: Record<string, unknown> = {
+    Language: { select: { name: language } },
+  };
+
+  const pageId = await createNotionPageWithBlocks(
+    notion,
+    parentId,
+    databaseId,
+    title,
+    blocks,
+    properties,
+    language,
+    undefined, // no existingPageId
+    true // forceCreate — always creates new page
+  );
+
+  console.log(`Created Notion page: ${pageId}`);
+  console.log(`   View: https://notion.so/${pageId.replace(/-/g, "")}`);
+}
+
+run().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error("Push failed:", message);
+  process.exit(1);
+});

--- a/scripts/push-new-translation-to-notion.ts
+++ b/scripts/push-new-translation-to-notion.ts
@@ -49,8 +49,11 @@ function parseSimpleFrontmatter(content: string): Record<string, string> {
   return result;
 }
 
-function parseArgs(): { file: string; language: string } {
-  const args = process.argv.slice(2);
+function parseArgs(argsOverride?: string[]): {
+  file: string;
+  language: string;
+} {
+  const args = argsOverride ?? process.argv.slice(2);
   const fileIndex = args.indexOf("--file");
   const languageIndex = args.indexOf("--language");
 
@@ -74,8 +77,8 @@ function parseArgs(): { file: string; language: string } {
   return { file: args[fileIndex + 1], language };
 }
 
-async function run() {
-  const { file, language } = parseArgs();
+export async function run(argsOverride?: string[]) {
+  const { file, language } = parseArgs(argsOverride);
 
   const filePath = path.resolve(file);
   const sidecarPath = filePath.replace(/\.md$/i, ".notion.json");
@@ -150,8 +153,10 @@ async function run() {
   console.log(`   View: https://notion.so/${pageId.replace(/-/g, "")}`);
 }
 
-run().catch((err: unknown) => {
-  const message = err instanceof Error ? err.message : String(err);
-  console.error("Push failed:", message);
-  process.exit(1);
-});
+if (import.meta.main) {
+  run().catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error("Push failed:", message);
+    process.exit(1);
+  });
+}

--- a/scripts/push-new-translation-to-notion.ts
+++ b/scripts/push-new-translation-to-notion.ts
@@ -11,6 +11,7 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import dotenv from "dotenv";
+import { parse as parseYaml } from "yaml";
 import { createNotionPageWithBlocks } from "./notion-translate/translateBlocks.js";
 import { notion } from "./notionClient.js";
 import { LANGUAGES, getAutomatedLanguageCode } from "./constants.js";
@@ -20,12 +21,11 @@ dotenv.config({ override: true });
 const DATA_SOURCE_ID = process.env.DATA_SOURCE_ID ?? "";
 const DATABASE_ID = process.env.DATABASE_ID ?? "";
 
-/** Minimal frontmatter parser — splits on --- delimiters and parses key: value pairs. */
+/** Frontmatter parser — extracts YAML between --- delimiters and parses with the yaml package. */
 function parseSimpleFrontmatter(content: string): Record<string, string> {
-  const result: Record<string, string> = {};
   const trimmed = content.trimStart();
 
-  if (!trimmed.startsWith("---")) return result;
+  if (!trimmed.startsWith("---")) return {};
 
   // Find the closing delimiter as a standalone line (not just "---" anywhere in YAML values)
   const lines = trimmed.split("\n");
@@ -37,24 +37,20 @@ function parseSimpleFrontmatter(content: string): Record<string, string> {
       break;
     }
   }
-  if (closingLine === -1) return result;
+  if (closingLine === -1) return {};
 
-  const yaml = lines.slice(1, closingLine).join("\n").trim();
+  const yamlContent = lines.slice(1, closingLine).join("\n");
+  const parsed = parseYaml(yamlContent) as Record<string, unknown>;
 
-  for (const line of yaml.split("\n")) {
-    const colonIndex = line.indexOf(":");
-    if (colonIndex === -1) continue;
-    const key = line.slice(0, colonIndex).trim();
-    const value = line
-      .slice(colonIndex + 1)
-      .trim()
-      .replace(/^['"]|['"]$/g, "");
-    if (key) {
-      // eslint-disable-next-line security/detect-object-injection -- key comes from frontmatter line parsing, not user input
+  if (!parsed || typeof parsed !== "object") return {};
+
+  const result: Record<string, string> = {};
+  for (const [key, value] of Object.entries(parsed)) {
+    if (typeof value === "string") {
+      // eslint-disable-next-line security/detect-object-injection -- key comes from YAML parsing, not user input
       result[key] = value;
     }
   }
-
   return result;
 }
 
@@ -119,11 +115,9 @@ export async function run(argsOverride?: string[]) {
     sourceProperties?: Record<string, unknown>;
   };
 
-  // Support both wrapped format { parentId, blocks } and legacy bare array
-  const blocks = (
-    Array.isArray(sidecarParsed) ? sidecarParsed : (sidecar.blocks ?? [])
-  ) as import("@notionhq/client/build/src/api-endpoints").BlockObjectRequest[];
-  const parentId = !Array.isArray(sidecarParsed) ? sidecar.parentId : undefined;
+  const blocks = (sidecar.blocks ??
+    []) as import("@notionhq/client/build/src/api-endpoints").BlockObjectRequest[];
+  const parentId = sidecar.parentId;
 
   if (!parentId) {
     throw new Error(

--- a/scripts/push-new-translation-to-notion.ts
+++ b/scripts/push-new-translation-to-notion.ts
@@ -3,7 +3,7 @@
  * Push a pre-translated automated translation file to Notion as a new page.
  *
  * Usage:
- *   bun scripts/push-new-translation-to-notion.ts --file <path> --language <"PT - automated"|"ES - automated">
+ *   bun scripts/push-new-translation-to-notion.ts --file <path> --language <automated-language-code>
  *
  * Requires: the file to have a corresponding .notion.json sidecar from a Notion-API translation run.
  * Does NOT work with files generated in --local-only mode (no sidecar).
@@ -13,6 +13,7 @@ import path from "node:path";
 import dotenv from "dotenv";
 import { createNotionPageWithBlocks } from "./notion-translate/translateBlocks.js";
 import { notion } from "./notionClient.js";
+import { LANGUAGES, getAutomatedLanguageCode } from "./constants.js";
 
 dotenv.config({ override: true });
 
@@ -57,15 +58,16 @@ function parseArgs(): { file: string; language: string } {
     throw new Error("Missing --file argument");
   }
   if (languageIndex === -1 || !args[languageIndex + 1]) {
-    throw new Error(
-      "Missing --language argument. Expected: 'PT - automated' or 'ES - automated'"
-    );
+    throw new Error("Missing --language argument");
   }
 
   const language = args[languageIndex + 1];
-  if (language !== "PT - automated" && language !== "ES - automated") {
+  const validAutomatedLanguages = LANGUAGES.map((lang) =>
+    getAutomatedLanguageCode(lang.notionLangCode)
+  );
+  if (!validAutomatedLanguages.includes(language)) {
     throw new Error(
-      `Invalid --language value: "${language}". Expected: 'PT - automated' or 'ES - automated'`
+      `Invalid --language value: "${language}". Expected one of: ${validAutomatedLanguages.map((l) => `'${l}'`).join(", ")}`
     );
   }
 
@@ -102,6 +104,7 @@ async function run() {
   const sidecar = sidecarParsed as {
     parentId?: string;
     blocks?: unknown[];
+    sourceProperties?: Record<string, unknown>;
   };
 
   // Support both wrapped format { parentId, blocks } and legacy bare array
@@ -127,6 +130,7 @@ async function run() {
   console.log(`Creating Notion page: "${title}" under parent ${parentId}`);
 
   const properties: Record<string, unknown> = {
+    ...(sidecar.sourceProperties || {}),
     Language: { select: { name: language } },
   };
 

--- a/scripts/push-new-translation-to-notion.ts
+++ b/scripts/push-new-translation-to-notion.ts
@@ -27,10 +27,19 @@ function parseSimpleFrontmatter(content: string): Record<string, string> {
 
   if (!trimmed.startsWith("---")) return result;
 
-  const closingIndex = trimmed.indexOf("---", 3);
-  if (closingIndex === -1) return result;
+  // Find the closing delimiter as a standalone line (not just "---" anywhere in YAML values)
+  const lines = trimmed.split("\n");
+  let closingLine = -1;
+  for (let i = 1; i < lines.length; i++) {
+    // eslint-disable-next-line security/detect-object-injection -- numeric index from for-loop, not user-controlled
+    if (lines[i].trimEnd() === "---") {
+      closingLine = i;
+      break;
+    }
+  }
+  if (closingLine === -1) return result;
 
-  const yaml = trimmed.slice(3, closingIndex).trim();
+  const yaml = lines.slice(1, closingLine).join("\n").trim();
 
   for (const line of yaml.split("\n")) {
     const colonIndex = line.indexOf(":");

--- a/scripts/run-single-page-translation.ts
+++ b/scripts/run-single-page-translation.ts
@@ -14,8 +14,7 @@ import { getAutomatedOutputDir, LANGUAGES } from "./constants.js";
 import { resolveCanonicalDocsRelativePath } from "./notion-fetch/pageMetadataCache.js";
 import { main } from "./notion-translate/index.js";
 
-const DEFAULT_PAGE_ID = "2331b08162d58090ab6ad6c1c5f60dda";
-const MINUTE_BOUNDARY_BUFFER_MS = 1500;
+const MINUTE_BOUNDARY_BUFFER_MS = 100;
 
 type FileSnapshot = {
   hash: string;
@@ -189,22 +188,36 @@ function getLanguageTargets(
 }
 
 async function waitForNextAutomatedTimestampWindow(): Promise<void> {
-  const now = new Date();
-  const nextMinute = new Date(now);
-  nextMinute.setSeconds(60, 0);
-  const waitMs =
-    nextMinute.getTime() - now.getTime() + MINUTE_BOUNDARY_BUFFER_MS;
-
   console.log(
-    `\nWaiting ${waitMs}ms for the next minute boundary so automated artifact names must advance...`
+    `\nWaiting ${MINUTE_BOUNDARY_BUFFER_MS}ms between runs to ensure distinct millisecond timestamps...`
   );
-  await sleep(waitMs);
+  await sleep(MINUTE_BOUNDARY_BUFFER_MS);
 }
 
 async function run() {
   const args = process.argv.slice(2);
-  const pageIdIndex = args.indexOf("--page-id");
-  const pageId = pageIdIndex !== -1 ? args[pageIdIndex + 1] : DEFAULT_PAGE_ID;
+  const pageIdArg = args.find(
+    (a) => a === "--page-id" || a.startsWith("--page-id=")
+  );
+  let pageId: string | undefined;
+  if (pageIdArg) {
+    if (pageIdArg.includes("=")) {
+      pageId = pageIdArg.split("=")[1];
+    } else {
+      const idx = args.indexOf(pageIdArg);
+      pageId = args[idx + 1];
+    }
+  }
+
+  if (!pageId) {
+    console.error(
+      "Error: Missing required argument --page-id.\n" +
+        "Usage: bun run notion:translate-test --page-id <notion-page-id>\n" +
+        "Example: bun run notion:translate-test --page-id 2331b08162d58090ab6ad6c1c5f60dda"
+    );
+    process.exit(1);
+  }
+
   const canonicalRelativePath = getCanonicalRelativePath(pageId);
   const languageTargets = getLanguageTargets(canonicalRelativePath);
 
@@ -332,7 +345,7 @@ async function run() {
     if (result.newAutomatedFiles.length === 0) {
       const changedArtifactsHint =
         result.changedAutomatedFiles.length > 0
-          ? ` (${result.changedAutomatedFiles.length} same-name artifact${result.changedAutomatedFiles.length === 1 ? " was" : "s were"} modified in place, which usually means both runs landed in the same minute window)`
+          ? ` (${result.changedAutomatedFiles.length} same-name artifact${result.changedAutomatedFiles.length === 1 ? " was" : "s were"} modified in place, which usually means both runs landed in the same millisecond window)`
           : "";
       failures.push(
         `${result.language}: no new page-specific automated file was created on run 2 for ${canonicalRelativePath}${changedArtifactsHint}`

--- a/scripts/run-single-page-translation.ts
+++ b/scripts/run-single-page-translation.ts
@@ -1,0 +1,78 @@
+#!/usr/bin/env bun
+/**
+ * Smoke-test script for the no-overwrite translation strategy.
+ * Runs the translate pipeline twice for a single page to verify that:
+ *   1. The first run creates baseline i18n files.
+ *   2. The second run creates new automated-translations/ files (not overwriting i18n).
+ */
+import { main } from "./notion-translate/index.js";
+import fs from "node:fs/promises";
+import path from "node:path";
+
+const DEFAULT_PAGE_ID = "2331b08162d58090ab6ad6c1c5f60dda";
+
+async function run() {
+  const args = process.argv.slice(2);
+  const pageIdIndex = args.indexOf("--page-id");
+  const pageId = pageIdIndex !== -1 ? args[pageIdIndex + 1] : DEFAULT_PAGE_ID;
+
+  console.log(`\n=== No-Overwrite Smoke Test ===`);
+  console.log(`Page: ${pageId}`);
+
+  // Step 1: First run — creates baseline i18n files
+  console.log(`\n--- Run 1: baseline i18n creation ---`);
+  const summary1 = await main({ pageId, localOnly: true });
+  console.log(
+    `Run 1 summary: new=${summary1.newTranslations}, automated=${summary1.automatedTranslations}`
+  );
+
+  // Step 2: Second run — should route existing translations to automated path
+  console.log(`\n--- Run 2: no-overwrite automated path ---`);
+  const summary2 = await main({ pageId, localOnly: true });
+  console.log(
+    `Run 2 summary: new=${summary2.newTranslations}, automated=${summary2.automatedTranslations}`
+  );
+
+  // Verify: automated-translations/ directories should have new files
+  const ptDir = path.resolve("./automated-translations/pt");
+  const esDir = path.resolve("./automated-translations/es");
+
+  let ptFiles: string[] = [];
+  let esFiles: string[] = [];
+  try {
+    ptFiles = (await fs.readdir(ptDir, { recursive: true })).filter((f) =>
+      (f as string).endsWith(".md")
+    ) as string[];
+    esFiles = (await fs.readdir(esDir, { recursive: true })).filter((f) =>
+      (f as string).endsWith(".md")
+    ) as string[];
+  } catch {
+    // Directories may not exist if no automated translations were made
+  }
+
+  console.log(`\n--- Results ---`);
+  console.log(`PT automated files: ${ptFiles.length}`);
+  ptFiles.forEach((f) => console.log(`  ${f}`));
+  console.log(`ES automated files: ${esFiles.length}`);
+  esFiles.forEach((f) => console.log(`  ${f}`));
+
+  const hasAutomated = ptFiles.length > 0 || esFiles.length > 0;
+  if (summary2.automatedTranslations > 0 || hasAutomated) {
+    console.log(
+      `\nNo-overwrite behavior verified: automated files created on second run`
+    );
+  } else {
+    console.log(
+      `\nNo automated translations on second run — check if i18n files exist for the page`
+    );
+    console.log(
+      `   (This is expected if the page has no existing i18n files yet)`
+    );
+  }
+}
+
+run().catch((err: unknown) => {
+  const message = err instanceof Error ? err.message : String(err);
+  console.error("Smoke test failed:", message);
+  process.exit(1);
+});

--- a/scripts/run-single-page-translation.ts
+++ b/scripts/run-single-page-translation.ts
@@ -1,74 +1,357 @@
 #!/usr/bin/env bun
 /**
- * Smoke-test script for the no-overwrite translation strategy.
+ * Smoke-test script for page-specific no-overwrite translation behavior.
  * Runs the translate pipeline twice for a single page to verify that:
- *   1. The first run creates baseline i18n files.
- *   2. The second run creates new automated-translations/ files (not overwriting i18n).
+ *   1. The page has baseline i18n files after the first run.
+ *   2. The second run leaves those page-specific i18n files untouched.
+ *   3. The second run creates new automated-translations files for that same page.
  */
-import { main } from "./notion-translate/index.js";
+import { createHash } from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+import { getAutomatedOutputDir, LANGUAGES } from "./constants.js";
+import { resolveCanonicalDocsRelativePath } from "./notion-fetch/pageMetadataCache.js";
+import { main } from "./notion-translate/index.js";
 
 const DEFAULT_PAGE_ID = "2331b08162d58090ab6ad6c1c5f60dda";
+const MINUTE_BOUNDARY_BUFFER_MS = 1500;
+
+type FileSnapshot = {
+  hash: string;
+  sizeBytes: number;
+  mtimeMs: number;
+};
+
+type AutomatedFileSnapshots = Map<string, FileSnapshot>;
+
+type LanguageSmokeTarget = {
+  language: string;
+  i18nPath: string;
+  automatedDir: string;
+};
+
+function toPosixPath(filePath: string): string {
+  return filePath.split(path.sep).join("/");
+}
+
+function formatProjectPath(filePath: string): string {
+  return toPosixPath(path.relative(process.cwd(), filePath));
+}
+
+function getAutomatedFilePrefix(canonicalRelativePath: string): string {
+  return `${toPosixPath(canonicalRelativePath.replace(/\.md$/i, ""))}-`;
+}
+
+async function fileExists(filePath: string): Promise<boolean> {
+  try {
+    await fs.access(filePath);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function snapshotFile(filePath: string): Promise<FileSnapshot> {
+  const [content, stats] = await Promise.all([
+    fs.readFile(filePath, "utf8"),
+    fs.stat(filePath),
+  ]);
+
+  return {
+    hash: createHash("sha256").update(content).digest("hex"),
+    sizeBytes: Buffer.byteLength(content, "utf8"),
+    mtimeMs: stats.mtimeMs,
+  };
+}
+
+async function listPageAutomatedMarkdownFiles(
+  automatedDir: string,
+  canonicalRelativePath: string
+): Promise<string[]> {
+  try {
+    const pagePrefix = getAutomatedFilePrefix(canonicalRelativePath);
+    return ((await fs.readdir(automatedDir, { recursive: true })) as string[])
+      .map((entry) => toPosixPath(entry))
+      .filter((entry) => entry.startsWith(pagePrefix) && entry.endsWith(".md"))
+      .sort();
+  } catch {
+    return [];
+  }
+}
+
+async function snapshotAutomatedMarkdownFiles(
+  automatedDir: string,
+  canonicalRelativePath: string
+): Promise<AutomatedFileSnapshots> {
+  const filePaths = await listPageAutomatedMarkdownFiles(
+    automatedDir,
+    canonicalRelativePath
+  );
+  const snapshots = await Promise.all(
+    filePaths.map(
+      async (relativePath) =>
+        [
+          relativePath,
+          await snapshotFile(path.join(automatedDir, relativePath)),
+        ] as [string, FileSnapshot]
+    )
+  );
+
+  return new Map(snapshots);
+}
+
+function hasFileSnapshotChanged(
+  before: FileSnapshot,
+  after: FileSnapshot
+): boolean {
+  return (
+    before.hash !== after.hash ||
+    before.sizeBytes !== after.sizeBytes ||
+    before.mtimeMs !== after.mtimeMs
+  );
+}
+
+function describeAutomatedArtifactDelta(
+  beforeSnapshots: AutomatedFileSnapshots,
+  afterSnapshots: AutomatedFileSnapshots
+): {
+  newFiles: string[];
+  changedFiles: string[];
+} {
+  const newFiles: string[] = [];
+  const changedFiles: string[] = [];
+
+  for (const [relativePath, afterSnapshot] of afterSnapshots.entries()) {
+    const beforeSnapshot = beforeSnapshots.get(relativePath);
+    if (!beforeSnapshot) {
+      newFiles.push(relativePath);
+      continue;
+    }
+
+    if (hasFileSnapshotChanged(beforeSnapshot, afterSnapshot)) {
+      changedFiles.push(relativePath);
+    }
+  }
+
+  return { newFiles, changedFiles };
+}
+
+function formatAutomatedArtifactOutcome(
+  newFiles: string[],
+  changedFiles: string[]
+): string {
+  if (newFiles.length > 0) {
+    return `${newFiles.length} new file${newFiles.length === 1 ? "" : "s"}`;
+  }
+
+  if (changedFiles.length > 0) {
+    return `${changedFiles.length} same-name file${changedFiles.length === 1 ? "" : "s"} changed in place`;
+  }
+
+  return "no artifact changes detected";
+}
+
+function getCanonicalRelativePath(pageId: string): string {
+  const canonicalRelativePath = resolveCanonicalDocsRelativePath(pageId);
+  if (!canonicalRelativePath) {
+    throw new Error(
+      `No canonical docs path found for page ${pageId}. This smoke test needs a cached docs-relative path to verify page-specific output.`
+    );
+  }
+
+  if (!/\.(md|mdx)$/i.test(canonicalRelativePath)) {
+    throw new Error(
+      `Smoke test only supports markdown-backed pages. Resolved path was ${canonicalRelativePath}.`
+    );
+  }
+
+  return canonicalRelativePath;
+}
+
+function getLanguageTargets(
+  canonicalRelativePath: string
+): LanguageSmokeTarget[] {
+  return LANGUAGES.map((config) => {
+    const automatedDir = getAutomatedOutputDir(config.language);
+    if (!automatedDir) {
+      throw new Error(
+        `No automated output directory configured for ${config.language}`
+      );
+    }
+
+    return {
+      language: config.language,
+      i18nPath: path.resolve(config.outputDir, canonicalRelativePath),
+      automatedDir: path.resolve(automatedDir),
+    };
+  });
+}
+
+async function waitForNextAutomatedTimestampWindow(): Promise<void> {
+  const now = new Date();
+  const nextMinute = new Date(now);
+  nextMinute.setSeconds(60, 0);
+  const waitMs =
+    nextMinute.getTime() - now.getTime() + MINUTE_BOUNDARY_BUFFER_MS;
+
+  console.log(
+    `\nWaiting ${waitMs}ms for the next minute boundary so automated artifact names must advance...`
+  );
+  await sleep(waitMs);
+}
 
 async function run() {
   const args = process.argv.slice(2);
   const pageIdIndex = args.indexOf("--page-id");
   const pageId = pageIdIndex !== -1 ? args[pageIdIndex + 1] : DEFAULT_PAGE_ID;
+  const canonicalRelativePath = getCanonicalRelativePath(pageId);
+  const languageTargets = getLanguageTargets(canonicalRelativePath);
 
-  console.log(`\n=== No-Overwrite Smoke Test ===`);
+  console.log(`\n=== Page-Specific No-Overwrite Smoke Test ===`);
   console.log(`Page: ${pageId}`);
+  console.log(`Canonical docs path: ${canonicalRelativePath}`);
+  console.log(
+    `Automated file pattern: ${getAutomatedFilePrefix(canonicalRelativePath)}*.md`
+  );
 
-  // Step 1: First run — creates baseline i18n files
-  console.log(`\n--- Run 1: baseline i18n creation ---`);
+  const existedBeforeRun1 = await Promise.all(
+    languageTargets.map(async (target) => ({
+      language: target.language,
+      exists: await fileExists(target.i18nPath),
+    }))
+  );
+
+  console.log(`\n--- Run 1: establish or reuse baseline i18n files ---`);
   const summary1 = await main({ pageId, localOnly: true });
   console.log(
     `Run 1 summary: new=${summary1.newTranslations}, automated=${summary1.automatedTranslations}`
   );
 
-  // Step 2: Second run — should route existing translations to automated path
-  console.log(`\n--- Run 2: no-overwrite automated path ---`);
+  const baselineState = await Promise.all(
+    languageTargets.map(async (target) => {
+      const baselineExists = await fileExists(target.i18nPath);
+      if (!baselineExists) {
+        throw new Error(
+          `Expected baseline i18n file for ${target.language} at ${formatProjectPath(target.i18nPath)} after run 1`
+        );
+      }
+
+      return {
+        ...target,
+        existedBeforeRun1:
+          existedBeforeRun1.find((entry) => entry.language === target.language)
+            ?.exists ?? false,
+        i18nSnapshotBeforeRun2: await snapshotFile(target.i18nPath),
+        automatedFileSnapshotsBeforeRun2: await snapshotAutomatedMarkdownFiles(
+          target.automatedDir,
+          canonicalRelativePath
+        ),
+      };
+    })
+  );
+
+  console.log(`\nBaseline state after run 1:`);
+  baselineState.forEach((state) => {
+    console.log(
+      `  ${state.language}: ${formatProjectPath(state.i18nPath)} (${state.existedBeforeRun1 ? "pre-existing" : "created/refreshed by run 1"})`
+    );
+  });
+
+  await waitForNextAutomatedTimestampWindow();
+
+  console.log(`\n--- Run 2: verify page-specific no-overwrite behavior ---`);
   const summary2 = await main({ pageId, localOnly: true });
   console.log(
     `Run 2 summary: new=${summary2.newTranslations}, automated=${summary2.automatedTranslations}`
   );
 
-  // Verify: automated-translations/ directories should have new files
-  const ptDir = path.resolve("./automated-translations/pt");
-  const esDir = path.resolve("./automated-translations/es");
+  const verificationResults = await Promise.all(
+    baselineState.map(async (state) => {
+      const i18nSnapshotAfterRun2 = await snapshotFile(state.i18nPath);
+      const automatedFileSnapshotsAfterRun2 =
+        await snapshotAutomatedMarkdownFiles(
+          state.automatedDir,
+          canonicalRelativePath
+        );
+      const { newFiles, changedFiles } = describeAutomatedArtifactDelta(
+        state.automatedFileSnapshotsBeforeRun2,
+        automatedFileSnapshotsAfterRun2
+      );
+      const contentChanged =
+        i18nSnapshotAfterRun2.hash !== state.i18nSnapshotBeforeRun2.hash ||
+        i18nSnapshotAfterRun2.sizeBytes !==
+          state.i18nSnapshotBeforeRun2.sizeBytes;
+      const timestampChanged =
+        i18nSnapshotAfterRun2.mtimeMs !== state.i18nSnapshotBeforeRun2.mtimeMs;
 
-  let ptFiles: string[] = [];
-  let esFiles: string[] = [];
-  try {
-    ptFiles = (await fs.readdir(ptDir, { recursive: true })).filter((f) =>
-      (f as string).endsWith(".md")
-    ) as string[];
-    esFiles = (await fs.readdir(esDir, { recursive: true })).filter((f) =>
-      (f as string).endsWith(".md")
-    ) as string[];
-  } catch {
-    // Directories may not exist if no automated translations were made
+      return {
+        ...state,
+        newAutomatedFiles: newFiles,
+        changedAutomatedFiles: changedFiles,
+        automatedFileCountAfterRun2: automatedFileSnapshotsAfterRun2.size,
+        contentChanged,
+        timestampChanged,
+      };
+    })
+  );
+
+  console.log(`\n--- Verification Results ---`);
+  verificationResults.forEach((result) => {
+    console.log(`\n${result.language}`);
+    console.log(`  i18n file: ${formatProjectPath(result.i18nPath)}`);
+    console.log(
+      `  i18n unchanged after run 2: ${!result.contentChanged && !result.timestampChanged}`
+    );
+    console.log(
+      `  automated artifact outcome on run 2: ${formatAutomatedArtifactOutcome(result.newAutomatedFiles, result.changedAutomatedFiles)}`
+    );
+    console.log(
+      `  total page-specific automated files after run 2: ${result.automatedFileCountAfterRun2}`
+    );
+    result.newAutomatedFiles.forEach((file) => {
+      console.log(
+        `    new: ${formatProjectPath(path.join(result.automatedDir, file))}`
+      );
+    });
+    result.changedAutomatedFiles.forEach((file) => {
+      console.log(
+        `    changed-in-place: ${formatProjectPath(path.join(result.automatedDir, file))}`
+      );
+    });
+  });
+
+  const failures: string[] = [];
+  for (const result of verificationResults) {
+    if (result.contentChanged || result.timestampChanged) {
+      failures.push(
+        `${result.language}: baseline i18n file changed after run 2 (${formatProjectPath(result.i18nPath)})`
+      );
+    }
+
+    if (result.newAutomatedFiles.length === 0) {
+      const changedArtifactsHint =
+        result.changedAutomatedFiles.length > 0
+          ? ` (${result.changedAutomatedFiles.length} same-name artifact${result.changedAutomatedFiles.length === 1 ? " was" : "s were"} modified in place, which usually means both runs landed in the same minute window)`
+          : "";
+      failures.push(
+        `${result.language}: no new page-specific automated file was created on run 2 for ${canonicalRelativePath}${changedArtifactsHint}`
+      );
+    }
   }
 
-  console.log(`\n--- Results ---`);
-  console.log(`PT automated files: ${ptFiles.length}`);
-  ptFiles.forEach((f) => console.log(`  ${f}`));
-  console.log(`ES automated files: ${esFiles.length}`);
-  esFiles.forEach((f) => console.log(`  ${f}`));
-
-  const hasAutomated = ptFiles.length > 0 || esFiles.length > 0;
-  if (summary2.automatedTranslations > 0 || hasAutomated) {
-    console.log(
-      `\nNo-overwrite behavior verified: automated files created on second run`
-    );
-  } else {
-    console.log(
-      `\nNo automated translations on second run — check if i18n files exist for the page`
-    );
-    console.log(
-      `   (This is expected if the page has no existing i18n files yet)`
+  if (failures.length > 0) {
+    throw new Error(
+      [
+        "Page-specific no-overwrite verification failed:",
+        ...failures.map((failure) => `  - ${failure}`),
+      ].join("\n")
     );
   }
+
+  console.log(
+    `\nPage-specific no-overwrite behavior verified: run 2 created new automated artifacts for ${canonicalRelativePath} without touching the matching i18n files.`
+  );
 }
 
 run().catch((err: unknown) => {


### PR DESCRIPTION
## Summary

Fixes #171

When a translation already exists and the English source is newer, the pipeline previously overwrote the human-reviewed translation. This PR routes those cases to a safe **automated path** that creates a new versioned file instead of touching the existing one.

- **No existing translation** → normal creation path (unchanged)
- **Existing translation, English is newer** → automated path: new timestamped file + new Notion page with `Language = "PT - automated"` / `"ES - automated"`, using `forceCreate` to bypass DB deduplication
- **Verification error on block check** → same automated path (safe default)
- **`--local-only` + existing i18n file** → automated path, no Notion writes

### Key changes

| File | What changed |
|------|-------------|
| `scripts/constants.ts` | `AUTOMATED_LANGUAGE_MAP`, `AUTOMATED_OUTPUT_DIRS`, helper functions |
| `scripts/notion-translate/translateBlocks.ts` | `forceCreate` 9th param on `createNotionPageWithBlocks` |
| `scripts/notion-translate/index.ts` | `updateKind` discriminant on `TranslationUpdateResult`; `saveAutomatedTranslationToDisk()`; `processAutomatedTranslation()`; `automatedTranslations` counter wired through 4 locations |
| `scripts/push-new-translation-to-notion.ts` | New CLI to push a saved automated file to Notion (reads `parentId` from `.notion.json` sidecar) |
| `scripts/run-single-page-translation.ts` | Local smoke-test script |
| `scripts/notion-translate/__tests__/no-overwrite.test.ts` | 7 integration tests for all routing scenarios |

### Sidecar format

Automated translation runs now write a `.notion.json` sidecar alongside each `.md` file:

```json
{
  "parentId": "<notion-parent-block-id>",
  "blocks": [ ...translated Notion blocks... ]
}
```

The push script reads `parentId` from here — no need to add it to markdown frontmatter manually.

## Test plan

- [ ] All 7 no-overwrite scenarios pass (`bunx vitest run scripts/notion-translate/__tests__/no-overwrite.test.ts`)
- [ ] Full test suite: 3,224 passing, 1 pre-existing unrelated failure (`constants.test.ts` model name check), 0 new failures
- [ ] TypeScript: `bunx tsc --noEmit` — clean
- [ ] Lint: no new errors or warnings
- [ ] Live end-to-end: `bun run notion:translate -- --local-only --page-id <id>` should write to `automated-translations/` when a translation already exists

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a no-overwrite strategy for human-reviewed translations: when an existing translation is found and the English source is newer, instead of overwriting it the pipeline now creates a new versioned file in `automated-translations/` with millisecond-precision timestamps, optionally paired with a `.notion.json` sidecar for later Notion push. A new `processAutomatedTranslation` helper, `push-new-translation-to-notion.ts` CLI, and 7 integration tests cover all routing scenarios.

The three concerns raised in the previous review round (S3 URL leak in automated path, hardcoded page ID as default, same-second filename collision) are all addressed in the commit history.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three prior P0/P1 concerns are resolved; the one remaining finding is a P2 style query about an intentional guard removal.

The S3 URL leak in the automated path, hardcoded page ID default, and millisecond-timestamp collision are all addressed in the commit history. The only new finding is the removal of the `color: null` Notion write guard in `translateBlocks.ts`, which is speculative and does not constitute a confirmed current defect.

scripts/notion-translate/translateBlocks.ts — verify the intentional removal of the `color: null` cleanup guard.

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/notion-translate/index.ts | Core routing logic: adds `updateKind` discriminant, `processAutomatedTranslation`, `saveAutomatedTranslationToDisk`, and `getTranslatedBlocksForDisk`; wires `automatedTranslations` counter through four locations. S3 URL leak guard is now present in the automated path. |
| scripts/notion-translate/translateBlocks.ts | Adds `forceCreate` 9th param to `createNotionPageWithBlocks`, refactors `retryPageId` initialisation; restructures null-property cleanup — moves `icon: null` guard but drops the `color: null` guard entirely, a potential regression. |
| scripts/constants.ts | Adds `AUTOMATED_OUTPUT_DIRS`, `AUTOMATED_LANGUAGE_MAP`, and four helper functions; the `${code}-automated` fallback in `getAutomatedLanguageCode` is bounded by `validateAutomatedLanguageOptions` at call time. |
| scripts/push-new-translation-to-notion.ts | New CLI tool to push a pre-translated sidecar file to Notion; validates `--language` against known automated codes, checks sidecar existence, and uses `forceCreate` to bypass deduplication. |
| scripts/notion-translate/__tests__/no-overwrite.test.ts | 7 well-structured integration tests covering all routing scenarios (no translation, translation newer, English newer, empty translation, verification error, local-only, three-level hierarchy). |
| .github/workflows/translate-docs.yml | Wires `automatedTranslations` into the summary parse step and adds it to the Notion status-update gate condition; correctly set in `$GITHUB_OUTPUT`. |

</details>

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[processLanguageTranslations] --> B{localOnly?}
    B -- No --> C[findTranslationPage]
    C --> D[needsTranslationUpdate]
    D -- needsUpdate=false --> E[skip ⏭]
    D -- updateKind=no-translation\nor empty-translation --> F[processSinglePageTranslation\nnormal path]
    D -- updateKind=newer-english\nor verification-error\nAND translationPage≠null --> G[automatedPathNeeded=true]
    B -- Yes --> H{i18n file exists\non disk?}
    H -- No --> F
    H -- Yes --> G
    G --> I{sectionType=toggle?}
    I -- Yes --> E
    I -- No --> J[processAutomatedTranslation]
    J --> K[translateText + S3 guard]
    K --> L{localOnly?}
    L -- No --> M[translateNotionBlocks\ncreateNotionPageWithBlocks\nforceCreate=true]
    L -- Yes --> N[skip Notion write]
    M --> O[saveAutomatedTranslationToDisk\n+ .notion.json sidecar]
    N --> O
    O --> P[onNew ➜ automatedTranslations++]
    F --> Q[new/updated translation\nin i18n dir]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: scripts/notion-translate/translateBlocks.ts
Line: 250-254

Comment:
**`color: null` guard dropped in refactor**

The original code deleted both `icon: null` and `color: null` from block type objects before writing to Notion, with an explicit comment: *"Notion returns as null but rejects on append."* The refactor kept the `icon` guard but removed the `color` guard entirely. If the Notion API still rejects `color: null` on block-append calls, any block whose runtime `color` property is `null` will silently fail or return an API error on the first write after this change.

If the removal is intentional (e.g., Notion now accepts `null` for `color` or it was never actually null in practice), a brief comment explaining why would prevent future re-introduction of the guard.

```suggestion
      // Clean up unsupported properties that Notion API rejects on block creation.
      // The Notion API returns these fields when reading but rejects them as null on write.
      if ("icon" in typeObj && typeObj.icon === null) {
        delete typeObj.icon;
      }
      if ("color" in typeObj && typeObj.color === null) {
        delete typeObj.color;
      }
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (13): Last reviewed commit: ["fix(workflow): include automatedTranslat..."](https://github.com/digidem/comapeo-docs/commit/46c21136e9c44532ea3fe517ad621edcdfe25c1d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27542772)</sub>

<!-- /greptile_comment -->