### PR TITLE
fix(translate): strip null icon/color before Notion block append

### DIFF
--- a/scripts/notion-translate/translateBlocks.test.ts
+++ b/scripts/notion-translate/translateBlocks.test.ts
@@ -185,6 +185,80 @@ describe("translateNotionBlocksDirectly", () => {
     );
   });
 
+  it("strips null icon/color from block type objects (Notion returns null but rejects on append)", async () => {
+    mockBlocksChildrenList.mockResolvedValue(
+      blocksResponse([
+        {
+          id: "b-callout-null-icon",
+          type: "callout",
+          callout: {
+            rich_text: [
+              {
+                type: "text",
+                text: { content: "Callout text" },
+                plain_text: "Callout text",
+              },
+            ],
+            icon: null,
+            color: null,
+          },
+          has_children: false,
+        },
+        {
+          id: "b-callout-valid-icon",
+          type: "callout",
+          callout: {
+            rich_text: [
+              {
+                type: "text",
+                text: { content: "Keeps icon" },
+                plain_text: "Keeps icon",
+              },
+            ],
+            icon: { type: "emoji", emoji: "💡" },
+            color: "blue_background",
+          },
+          has_children: false,
+        },
+        {
+          id: "b-paragraph-null-color",
+          type: "paragraph",
+          paragraph: {
+            rich_text: [
+              {
+                type: "text",
+                text: { content: "Text" },
+                plain_text: "Text",
+              },
+            ],
+            color: null,
+          },
+          has_children: false,
+        },
+      ])
+    );
+
+    const { translateNotionBlocksDirectly } = await import("./translateBlocks");
+    const result = await translateNotionBlocksDirectly("page-id", "pt-BR");
+
+    // Null icon/color stripped from callout
+    const calloutNull = result[0] as Record<string, unknown>;
+    const calloutNullObj = calloutNull.callout as Record<string, unknown>;
+    expect(calloutNullObj.icon).toBeUndefined();
+    expect(calloutNullObj.color).toBeUndefined();
+
+    // Non-null icon/color preserved on callout
+    const calloutValid = result[1] as Record<string, unknown>;
+    const calloutValidObj = calloutValid.callout as Record<string, unknown>;
+    expect(calloutValidObj.icon).toEqual({ type: "emoji", emoji: "💡" });
+    expect(calloutValidObj.color).toBe("blue_background");
+
+    // Null color stripped from paragraph
+    const paragraph = result[2] as Record<string, unknown>;
+    const paragraphObj = paragraph.paragraph as Record<string, unknown>;
+    expect(paragraphObj.color).toBeUndefined();
+  });
+
   it("strips Notion-internal metadata fields from output blocks", async () => {
     mockBlocksChildrenList.mockResolvedValue(
       blocksResponse([

--- a/scripts/notion-translate/translateBlocks.ts
+++ b/scripts/notion-translate/translateBlocks.ts
@@ -171,6 +171,9 @@ async function translateBlocksTree(
     delete newBlock.archived;
     delete newBlock.in_trash;
     delete newBlock.children;
+    // Remove read-only/metadata fields that Notion rejects on block creation
+    delete newBlock.object;
+    delete newBlock.icon;
 
     if (
       newBlock.type === "child_page" ||
@@ -206,7 +209,7 @@ async function translateBlocksTree(
     }
 
     const blockType = newBlock.type as string;
-    // eslint-disable-next-line security/detect-object-injection -- blockType comes from Notion API block.type, not user input
+
     const typeObj = newBlock[blockType] as
       | (Record<string, unknown> & {
           url?: string;
@@ -218,6 +221,15 @@ async function translateBlocksTree(
         })
       | undefined;
     if (typeObj) {
+      // Strip read-only properties that Notion returns as null but rejects on append.
+      // The API expects these to be absent/undefined, not null.
+      if ("icon" in typeObj && typeObj.icon === null) {
+        delete typeObj.icon;
+      }
+      if ("color" in typeObj && typeObj.color === null) {
+        delete typeObj.color;
+      }
+
       if (typeObj.url) {
         const sanitized = sanitizeUrl(typeObj.url);
         if (sanitized) {
@@ -251,7 +263,6 @@ async function translateBlocksTree(
     }
 
     if (block.children) {
-      // eslint-disable-next-line security/detect-object-injection -- blockType comes from Notion API block.type, not user input
       const parentTypeObj = newBlock[blockType] as Record<string, unknown>;
       parentTypeObj.children = await translateBlocksTree(
         block.children,


### PR DESCRIPTION
## Summary

- Strip `null` `icon` and `color` fields from block type objects before appending to Notion pages. The Notion API returns these as `null` on read but rejects them with `validation_error` on append.
- Also strip top-level `object` and `icon` metadata fields that are read-only.
- Add test covering callout with null icon/color, callout with valid icon/color (preserved), and paragraph with null color.

Closes #180

## Root Cause

When Notion returns blocks (e.g. callout, paragraph), some properties like `icon` and `color` come back as `null`. When these blocks are sent back to Notion append children endpoint, the API rejects them: `body.children[N].paragraph.icon should be an object or undefined, instead was null`.

## How to Test

1. Check out this branch and run the unit tests:
   ```bash
   bunx vitest run scripts/notion-translate/translateBlocks.test.ts
   ```
2. All 7 tests should pass, including the new one: "strips null icon/color from block type objects (Notion returns null but rejects on append)"
3. To test against real Notion: trigger the translation workflow on a page with callout blocks (e.g. "Encryption & Security") and verify it no longer fails with `validation_error`.

## Test plan

- [x] Unit tests pass (`translateBlocks.test.ts`)
- [ ] Manual test: translate a page with callout blocks via CI workflow