### PR TITLE
fix(ci): use static/img pathspec in deploy content checkouts

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -174,7 +174,7 @@ jobs:
               echo "✅ Content branch fetched successfully"
 
               # Try to checkout content branch files
-              if git checkout origin/content -- docs/ i18n/ static/images/ 2>&1; then
+              if git checkout origin/content -- docs/ i18n/ static/img/ 2>&1; then
                 echo "✅ Content branch checkout successful"
                 CONTENT_BRANCH_SUCCESS="true"
               else
@@ -327,8 +327,8 @@ jobs:
             echo "⚠️  Note: No localized content (i18n/ is empty)"
           fi
 
-          if [ ! -d "static/images" ] || [ -z "$(ls -A static/images 2>/dev/null)" ]; then
-            echo "⚠️  Warning: static/images/ directory is empty or missing"
+          if [ ! -d "static/img" ] || [ -z "$(ls -A static/img 2>/dev/null)" ]; then
+            echo "⚠️  Warning: static/img/ directory is empty or missing"
           fi
 
           echo "✅ Content validated successfully"
@@ -336,7 +336,7 @@ jobs:
           echo "  - English docs: $DOCS_COUNT"
           echo "  - Localized docs: $I18N_COUNT"
           echo "  - Total docs: $TOTAL_CONTENT"
-          find static/images -type f 2>/dev/null | wc -l | xargs echo "  - Images:"
+          find static/img -type f 2>/dev/null | wc -l | xargs echo "  - Images:"
 
       - name: Build documentation
         # IS_PRODUCTION not set - generates noindex meta tags and disallow robots.txt

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -130,7 +130,7 @@ jobs:
 
           SHA="${{ steps.content-lock.outputs.sha }}"
           echo "📂 Checking out content at SHA ${SHA:0:8}..."
-          git checkout "$SHA" -- docs/ i18n/ static/images/
+          git checkout "$SHA" -- docs/ i18n/ static/img/
 
           # Validate content exists
           echo "🔍 Validating content..."
@@ -166,8 +166,8 @@ jobs:
             echo "   Docusaurus build may fail if default locale has no content"
           fi
 
-          if [ ! -d "static/images" ] || [ -z "$(ls -A static/images 2>/dev/null)" ]; then
-            echo "⚠️  Warning: static/images/ directory is empty or missing"
+          if [ ! -d "static/img" ] || [ -z "$(ls -A static/img 2>/dev/null)" ]; then
+            echo "⚠️  Warning: static/img/ directory is empty or missing"
             echo "Build will proceed but images may be unavailable"
           fi
 
@@ -176,7 +176,7 @@ jobs:
           echo "  - English docs: $DOCS_COUNT"
           echo "  - Localized docs: $I18N_COUNT"
           echo "  - Total docs: $TOTAL_CONTENT"
-          find static/images -type f 2>/dev/null | wc -l | xargs echo "  - Images:"
+          find static/img -type f 2>/dev/null | wc -l | xargs echo "  - Images:"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -14,7 +14,6 @@ on:
       - "package.json"
       - "docs/**"
       - "i18n/**"
-      - "static/images/**"
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
@@ -73,7 +72,7 @@ jobs:
                   REASON="main push without deploy-relevant code/config changes."
                 fi
               elif [ "$BRANCH_NAME" = "content" ]; then
-                if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(docs/|i18n/|static/images/)'; then
+                if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(docs/|i18n/|static/img/)'; then
                   SHOULD_DEPLOY="true"
                   REASON="content push includes generated content paths."
                 else
@@ -122,7 +121,7 @@ jobs:
           git fetch origin content
 
           echo "📂 Checking out content files..."
-          git checkout origin/content -- docs/ i18n/ static/images/
+          git checkout origin/content -- docs/ i18n/ static/img/
 
           # Validate content exists
           echo "🔍 Validating content..."
@@ -158,8 +157,8 @@ jobs:
             echo "   Docusaurus build may fail if default locale has no content"
           fi
 
-          if [ ! -d "static/images" ] || [ -z "$(ls -A static/images 2>/dev/null)" ]; then
-            echo "⚠️  Warning: static/images/ directory is empty or missing"
+          if [ ! -d "static/img" ] || [ -z "$(ls -A static/img 2>/dev/null)" ]; then
+            echo "⚠️  Warning: static/img/ directory is empty or missing"
             echo "Build will proceed but images may be unavailable"
           fi
 
@@ -168,7 +167,7 @@ jobs:
           echo "  - English docs: $DOCS_COUNT"
           echo "  - Localized docs: $I18N_COUNT"
           echo "  - Total docs: $TOTAL_CONTENT"
-          find static/images -type f 2>/dev/null | wc -l | xargs echo "  - Images:"
+          find static/img -type f 2>/dev/null | wc -l | xargs echo "  - Images:"
 
       - name: Setup Bun
         if: steps.detect.outputs.should_deploy == 'true'

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -26,7 +26,7 @@ jobs:
           git fetch origin content
 
           echo "📂 Checking out content files..."
-          git checkout origin/content -- docs/ i18n/ static/images/
+          git checkout origin/content -- docs/ i18n/ static/img/
 
           # Validate content exists
           echo "🔍 Validating content..."
@@ -62,8 +62,8 @@ jobs:
             echo "   Docusaurus build may fail if default locale has no content"
           fi
 
-          if [ ! -d "static/images" ] || [ -z "$(ls -A static/images 2>/dev/null)" ]; then
-            echo "⚠️  Warning: static/images/ directory is empty or missing"
+          if [ ! -d "static/img" ] || [ -z "$(ls -A static/img 2>/dev/null)" ]; then
+            echo "⚠️  Warning: static/img/ directory is empty or missing"
             echo "Build will proceed but images may be unavailable"
           fi
 
@@ -72,7 +72,7 @@ jobs:
           echo "  - English docs: $DOCS_COUNT"
           echo "  - Localized docs: $I18N_COUNT"
           echo "  - Total docs: $TOTAL_CONTENT"
-          find static/images -type f 2>/dev/null | wc -l | xargs echo "  - Images:"
+          find static/img -type f 2>/dev/null | wc -l | xargs echo "  - Images:"
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
## What

Deploy workflows checked out `docs/ i18n/ static/images/` from the content branch, but image assets live at `static/img/` (tracked on both `main` and `content`). `static/images/` does not exist anywhere, so the checkout failed:

```
error: pathspec 'static/images/' did not match any file(s) known to git
```

This is why production and staging deploys have been failing since the last green run on **2026-03-09**.

## Files

- `deploy-production.yml` — production died at content checkout (fatal)
- `deploy-staging.yml` — staging died the same way; trigger-decision grep (`:76`) and `paths` filter also referenced the wrong dir
- `deploy-test.yml` — same unguarded hard-fail
- `deploy-pr-preview.yml` — guarded with `if/else` fallback, so previews silently built without content-sourced images

Updates checkout pathspec, trigger-decision grep, `paths` filter, and empty-dir guards/counters across all four. `translate-docs.yml` + `.gitignore` still reference `static/images/` as part of content-branch gitignore management — left untouched to avoid disrupting the content sync mechanism.

## Verify

- `grep -rn "static/images" .github/workflows/deploy-*.yml` → none
- `prettier --check` on all four → unchanged (already formatted)
- `python3 yaml.safe_load` on all four → valid YAML

## Not in this PR (separate blocker)

`content-lock.sha` on `main` points at a **dead SHA** (`9849108…`, wiped by a content-branch rebase). This is fixed by running `Deploy to Production` via `workflow_dispatch` after this merges — it repromotes `origin/content` HEAD into the lock and deploys. Dispatch currently dies at the pathspec fixed here; once merged, it will succeed and rewrite the lock.

## Deploy steps (after merge)

1. `gh workflow run deploy-production.yml` (no inputs → uses `origin/content` HEAD `89030f6`)
2. Confirm `89030f6` ("translations-update: auto-translations") is approved production content first
3. Watch the run: `gh run watch`

## Notes

- No GitHub issue exists for this — discovered during deploy-readiness check.
- No i18n strings, no visual changes (CI-only).
- Branch is based off `origin/main` (`8ab4159`); local `main` has 3 unpushed commits (dep + Node 20 bumps) that are **not** included here and need separate approval to push.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes deploy workflows so content image assets are checked out from the existing `static/img` path. The main changes are:

- Production, staging, test, and PR preview content checkouts now use `static/img`.
- Image validation and image-count logging now read `static/img`.
- Staging deploy triggers now watch `static/img` for content-branch image changes.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

Changes are narrow CI path corrections, and repository context confirms `static/img` exists while `static/images` does not. No functional or security issues were identified in the changed workflows.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Proof logs were saved under trex-artifacts to capture the exact commands, working context in the combined proof log, captured command outputs, and exit statuses.
- An initial shell wrapper used /bin/sh with PIPESTATUS; the commands were rerun under bash -lc to ensure reliable capture of the Verify runs.
- Full GitHub Actions deploy execution was intentionally not attempted because it requires Actions runtime, secrets, and deployment state.

<a href="https://app.greptile.com/trex/runs/13837412/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-pr-preview.yml | Updates PR preview content-branch checkout and image validation/counting from `static/images` to `static/img`; no issues found. |
| .github/workflows/deploy-production.yml | Updates production locked-content checkout and image validation/counting to use `static/img`; no issues found. |
| .github/workflows/deploy-staging.yml | Updates staging path filters, deploy trigger detection, content checkout, and image validation/counting to use `static/img`; no issues found. |
| .github/workflows/deploy-test.yml | Updates test deploy content checkout and image validation/counting to use `static/img`; no issues found. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant Trigger as Workflow trigger
participant Checkout as Actions checkout
participant Content as content branch / locked SHA
participant Build as Docusaurus build
participant Deploy as Pages deploy

Trigger->>Checkout: Start deploy workflow
Checkout->>Content: Fetch content ref
Content-->>Checkout: docs/, i18n/, static/img/
Checkout->>Build: Validate content and image assets
Build->>Deploy: Upload/deploy built site
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant Trigger as Workflow trigger
participant Checkout as Actions checkout
participant Content as content branch / locked SHA
participant Build as Docusaurus build
participant Deploy as Pages deploy

Trigger->>Checkout: Start deploy workflow
Checkout->>Content: Fetch content ref
Content-->>Checkout: docs/, i18n/, static/img/
Checkout->>Build: Validate content and image assets
Build->>Deploy: Upload/deploy built site
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(ci): use static/img pathspec in depl..."](https://github.com/digidem/comapeo-docs/commit/8ba2aa82146f12e0d321d62ac98bb6d0e6235b12) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43007779)</sub>

<!-- /greptile_comment -->