### PR TITLE
Translate Docusaurus theme chrome (navbar, footer, code.json) for ES/PT

### DIFF
--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -355,9 +355,32 @@ jobs:
           git ls-files -z 'i18n/*/docusaurus-theme-classic/*' \
             | xargs -0 -r git checkout HEAD --
 
+          # `jq -s` slurps every JSON document across BOTH input files into
+          # one flat array and blindly indexes [0]/[1] — it does not verify
+          # each file actually contributed exactly one object. An empty or
+          # `null` content file silently falls back to HEAD alone; a content
+          # file with two concatenated JSON documents silently drops HEAD
+          # entirely. Validate each side is exactly one JSON object before
+          # merging so malformed input fails the step instead of shipping a
+          # silently wrong catalog.
+          validate_single_json_object() {
+            local file="$1" label="$2" count
+            count=$(jq -s 'length' "$file" 2>/dev/null) || { echo "::error::$label: not valid JSON" >&2; return 1; }
+            if [ "$count" != "1" ]; then
+              echo "::error::$label: expected exactly 1 JSON document, found $count" >&2
+              return 1
+            fi
+            jq -e 'type == "object"' "$file" >/dev/null 2>&1 || { echo "::error::$label: root value is not a JSON object" >&2; return 1; }
+          }
+
           git ls-files -z 'i18n/*/code.json' | while IFS= read -r -d '' f; do
-            jq -s '.[0] + .[1]' "$f" <(git show "HEAD:$f") > "$f.tmp"
+            head_tmp=$(mktemp)
+            git show "HEAD:$f" > "$head_tmp"
+            validate_single_json_object "$f" "$f (content overlay)"
+            validate_single_json_object "$head_tmp" "HEAD:$f"
+            jq -s '.[0] + .[1]' "$f" "$head_tmp" > "$f.tmp"
             mv "$f.tmp" "$f"
+            rm -f "$head_tmp"
           done
 
       - name: Build documentation

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -338,23 +338,17 @@ jobs:
           echo "  - Total docs: $TOTAL_CONTENT"
           find static/images -type f 2>/dev/null | wc -l | xargs echo "  - Images:"
 
-      - name: Restore PR-authored i18n changes
+      - name: Restore hand-maintained i18n files
         # The content-provisioning step above may have overlaid i18n/ from the
         # content branch (or regenerated it from Notion), silently discarding
-        # any i18n/ files this PR itself modified — e.g. theme translation
-        # (navbar.json, footer.json, code.json). Restore this PR's own
-        # versions of any i18n/ path it actually changed so the preview
-        # renders what the PR is proposing, not unrelated content-branch state.
+        # the hand-maintained theme translation files this repo owns
+        # (code.json, docusaurus-theme-classic/*). Restore them unconditionally
+        # from the checked-out PR ref so the preview renders what the PR is
+        # actually proposing, not unrelated content-branch state.
         run: |
           set -e
-          PR_I18N_CHANGES=$(git diff --name-only "origin/${{ github.event.pull_request.base.ref }}...HEAD" -- i18n/ || true)
-          if [ -n "$PR_I18N_CHANGES" ]; then
-            echo "Restoring PR-authored i18n files over content overlay:"
-            echo "$PR_I18N_CHANGES"
-            echo "$PR_I18N_CHANGES" | xargs -r git checkout HEAD --
-          else
-            echo "No PR-authored i18n/ changes to restore."
-          fi
+          git ls-files -z 'i18n/*/code.json' 'i18n/*/docusaurus-theme-classic/*' \
+            | xargs -0 -r git checkout HEAD --
 
       - name: Build documentation
         # IS_PRODUCTION not set - generates noindex meta tags and disallow robots.txt

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -356,7 +356,8 @@ jobs:
             | xargs -0 -r git checkout HEAD --
 
           git ls-files -z 'i18n/*/code.json' | while IFS= read -r -d '' f; do
-            jq -s '.[0] + .[1]' "$f" <(git show "HEAD:$f") > "$f.tmp" && mv "$f.tmp" "$f"
+            jq -s '.[0] + .[1]' "$f" <(git show "HEAD:$f") > "$f.tmp"
+            mv "$f.tmp" "$f"
           done
 
       - name: Build documentation

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -342,13 +342,22 @@ jobs:
         # The content-provisioning step above may have overlaid i18n/ from the
         # content branch (or regenerated it from Notion), silently discarding
         # the hand-maintained theme translation files this repo owns
-        # (code.json, docusaurus-theme-classic/*). Restore them unconditionally
-        # from the checked-out PR ref so the preview renders what the PR is
-        # actually proposing, not unrelated content-branch state.
+        # (docusaurus-theme-classic/*). Restore them unconditionally from the
+        # checked-out PR ref so the preview renders what the PR is actually
+        # proposing, not unrelated content-branch state.
+        #
+        # code.json also carries Notion-generated, content-only translation
+        # keys that live only on the content branch. A blind `checkout HEAD`
+        # here would silently drop those on every build. Merge instead: keep
+        # content-only keys, let HEAD win any key this repo also defines.
         run: |
           set -e
-          git ls-files -z 'i18n/*/code.json' 'i18n/*/docusaurus-theme-classic/*' \
+          git ls-files -z 'i18n/*/docusaurus-theme-classic/*' \
             | xargs -0 -r git checkout HEAD --
+
+          git ls-files -z 'i18n/*/code.json' | while IFS= read -r -d '' f; do
+            jq -s '.[0] + .[1]' "$f" <(git show "HEAD:$f") > "$f.tmp" && mv "$f.tmp" "$f"
+          done
 
       - name: Build documentation
         # IS_PRODUCTION not set - generates noindex meta tags and disallow robots.txt

--- a/.github/workflows/deploy-pr-preview.yml
+++ b/.github/workflows/deploy-pr-preview.yml
@@ -338,6 +338,24 @@ jobs:
           echo "  - Total docs: $TOTAL_CONTENT"
           find static/images -type f 2>/dev/null | wc -l | xargs echo "  - Images:"
 
+      - name: Restore PR-authored i18n changes
+        # The content-provisioning step above may have overlaid i18n/ from the
+        # content branch (or regenerated it from Notion), silently discarding
+        # any i18n/ files this PR itself modified — e.g. theme translation
+        # (navbar.json, footer.json, code.json). Restore this PR's own
+        # versions of any i18n/ path it actually changed so the preview
+        # renders what the PR is proposing, not unrelated content-branch state.
+        run: |
+          set -e
+          PR_I18N_CHANGES=$(git diff --name-only "origin/${{ github.event.pull_request.base.ref }}...HEAD" -- i18n/ || true)
+          if [ -n "$PR_I18N_CHANGES" ]; then
+            echo "Restoring PR-authored i18n files over content overlay:"
+            echo "$PR_I18N_CHANGES"
+            echo "$PR_I18N_CHANGES" | xargs -r git checkout HEAD --
+          else
+            echo "No PR-authored i18n/ changes to restore."
+          fi
+
       - name: Build documentation
         # IS_PRODUCTION not set - generates noindex meta tags and disallow robots.txt
         run: bun run build

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -148,7 +148,8 @@ jobs:
           # Merge instead: keep content-only keys, let HEAD win any key
           # this repo also defines.
           git ls-files -z 'i18n/*/code.json' | while IFS= read -r -d '' f; do
-            jq -s '.[0] + .[1]' "$f" <(git show "HEAD:$f") > "$f.tmp" && mv "$f.tmp" "$f"
+            jq -s '.[0] + .[1]' "$f" <(git show "HEAD:$f") > "$f.tmp"
+            mv "$f.tmp" "$f"
           done
 
           # Validate content exists
@@ -239,7 +240,14 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           echo "${SHA}" > content-lock.sha
           git add content-lock.sha
-          git commit -m "chore(content): promote content ${SHA:0:8} to production [skip ci]"
+
+          # Earlier steps in this job overlay content into i18n/ and merge
+          # code.json in the working tree only, without re-staging it — the
+          # index still holds the raw content-branch (unmerged) catalog. A
+          # plain `git commit` here would commit that whole index snapshot,
+          # silently regressing code.json on main. Scope the commit to
+          # content-lock.sha only so any other staged changes are ignored.
+          git commit content-lock.sha -m "chore(content): promote content ${SHA:0:8} to production [skip ci]"
           git push origin HEAD:main
           echo "✅ Updated content-lock.sha → ${SHA:0:8}"
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -132,6 +132,16 @@ jobs:
           echo "📂 Checking out content at SHA ${SHA:0:8}..."
           git checkout "$SHA" -- docs/ i18n/ static/images/
 
+          # The checkout above overlays i18n/ from the locked content SHA,
+          # which does not carry this repo's hand-maintained theme
+          # translation files (code.json, docusaurus-theme-classic/*) —
+          # those live only on main. Restore them from main so the theme
+          # chrome translations this repo owns actually reach production
+          # instead of silently falling back to whatever (or nothing) the
+          # content SHA has for those paths.
+          git ls-files -z 'i18n/*/code.json' 'i18n/*/docusaurus-theme-classic/*' \
+            | xargs -0 -r git checkout HEAD --
+
           # Validate content exists
           echo "🔍 Validating content..."
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -134,13 +134,22 @@ jobs:
 
           # The checkout above overlays i18n/ from the locked content SHA,
           # which does not carry this repo's hand-maintained theme
-          # translation files (code.json, docusaurus-theme-classic/*) —
-          # those live only on main. Restore them from main so the theme
-          # chrome translations this repo owns actually reach production
-          # instead of silently falling back to whatever (or nothing) the
-          # content SHA has for those paths.
-          git ls-files -z 'i18n/*/code.json' 'i18n/*/docusaurus-theme-classic/*' \
+          # translation files (docusaurus-theme-classic/*) — those live
+          # only on main. Restore them from main so the theme chrome
+          # translations this repo owns actually reach production instead
+          # of silently falling back to whatever (or nothing) the content
+          # SHA has for those paths.
+          git ls-files -z 'i18n/*/docusaurus-theme-classic/*' \
             | xargs -0 -r git checkout HEAD --
+
+          # code.json also carries Notion-generated, content-only
+          # translation keys that live only on the content SHA. A blind
+          # `checkout HEAD` here would silently drop those on every build.
+          # Merge instead: keep content-only keys, let HEAD win any key
+          # this repo also defines.
+          git ls-files -z 'i18n/*/code.json' | while IFS= read -r -d '' f; do
+            jq -s '.[0] + .[1]' "$f" <(git show "HEAD:$f") > "$f.tmp" && mv "$f.tmp" "$f"
+          done
 
           # Validate content exists
           echo "🔍 Validating content..."

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -147,9 +147,33 @@ jobs:
           # `checkout HEAD` here would silently drop those on every build.
           # Merge instead: keep content-only keys, let HEAD win any key
           # this repo also defines.
+          #
+          # `jq -s` slurps every JSON document across BOTH input files into
+          # one flat array and blindly indexes [0]/[1] — it does not verify
+          # each file actually contributed exactly one object. An empty or
+          # `null` content file silently falls back to HEAD alone; a content
+          # file with two concatenated JSON documents silently drops HEAD
+          # entirely. Validate each side is exactly one JSON object before
+          # merging so malformed input fails the step instead of shipping a
+          # silently wrong catalog.
+          validate_single_json_object() {
+            local file="$1" label="$2" count
+            count=$(jq -s 'length' "$file" 2>/dev/null) || { echo "::error::$label: not valid JSON" >&2; return 1; }
+            if [ "$count" != "1" ]; then
+              echo "::error::$label: expected exactly 1 JSON document, found $count" >&2
+              return 1
+            fi
+            jq -e 'type == "object"' "$file" >/dev/null 2>&1 || { echo "::error::$label: root value is not a JSON object" >&2; return 1; }
+          }
+
           git ls-files -z 'i18n/*/code.json' | while IFS= read -r -d '' f; do
-            jq -s '.[0] + .[1]' "$f" <(git show "HEAD:$f") > "$f.tmp"
+            head_tmp=$(mktemp)
+            git show "HEAD:$f" > "$head_tmp"
+            validate_single_json_object "$f" "$f (content overlay)"
+            validate_single_json_object "$head_tmp" "HEAD:$f"
+            jq -s '.[0] + .[1]' "$f" "$head_tmp" > "$f.tmp"
             mv "$f.tmp" "$f"
+            rm -f "$head_tmp"
           done
 
           # Validate content exists

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -140,7 +140,8 @@ jobs:
           # Merge instead: keep content-only keys, let HEAD win any key
           # this repo also defines.
           git ls-files -z 'i18n/*/code.json' | while IFS= read -r -d '' f; do
-            jq -s '.[0] + .[1]' "$f" <(git show "HEAD:$f") > "$f.tmp" && mv "$f.tmp" "$f"
+            jq -s '.[0] + .[1]' "$f" <(git show "HEAD:$f") > "$f.tmp"
+            mv "$f.tmp" "$f"
           done
 
           # Validate content exists

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -139,9 +139,33 @@ jobs:
           # `checkout HEAD` here would silently drop those on every build.
           # Merge instead: keep content-only keys, let HEAD win any key
           # this repo also defines.
+          #
+          # `jq -s` slurps every JSON document across BOTH input files into
+          # one flat array and blindly indexes [0]/[1] — it does not verify
+          # each file actually contributed exactly one object. An empty or
+          # `null` content file silently falls back to HEAD alone; a content
+          # file with two concatenated JSON documents silently drops HEAD
+          # entirely. Validate each side is exactly one JSON object before
+          # merging so malformed input fails the step instead of shipping a
+          # silently wrong catalog.
+          validate_single_json_object() {
+            local file="$1" label="$2" count
+            count=$(jq -s 'length' "$file" 2>/dev/null) || { echo "::error::$label: not valid JSON" >&2; return 1; }
+            if [ "$count" != "1" ]; then
+              echo "::error::$label: expected exactly 1 JSON document, found $count" >&2
+              return 1
+            fi
+            jq -e 'type == "object"' "$file" >/dev/null 2>&1 || { echo "::error::$label: root value is not a JSON object" >&2; return 1; }
+          }
+
           git ls-files -z 'i18n/*/code.json' | while IFS= read -r -d '' f; do
-            jq -s '.[0] + .[1]' "$f" <(git show "HEAD:$f") > "$f.tmp"
+            head_tmp=$(mktemp)
+            git show "HEAD:$f" > "$head_tmp"
+            validate_single_json_object "$f" "$f (content overlay)"
+            validate_single_json_object "$head_tmp" "HEAD:$f"
+            jq -s '.[0] + .[1]' "$f" "$head_tmp" > "$f.tmp"
             mv "$f.tmp" "$f"
+            rm -f "$head_tmp"
           done
 
           # Validate content exists

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -124,6 +124,16 @@ jobs:
           echo "📂 Checking out content files..."
           git checkout origin/content -- docs/ i18n/ static/images/
 
+          # The checkout above overlays i18n/ from the content branch,
+          # which does not carry this repo's hand-maintained theme
+          # translation files (code.json, docusaurus-theme-classic/*) —
+          # those live only on main. Restore them from main so the theme
+          # chrome translations this repo owns actually reach staging
+          # instead of silently falling back to whatever (or nothing) the
+          # content branch has for those paths.
+          git ls-files -z 'i18n/*/code.json' 'i18n/*/docusaurus-theme-classic/*' \
+            | xargs -0 -r git checkout HEAD --
+
           # Validate content exists
           echo "🔍 Validating content..."
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -126,13 +126,22 @@ jobs:
 
           # The checkout above overlays i18n/ from the content branch,
           # which does not carry this repo's hand-maintained theme
-          # translation files (code.json, docusaurus-theme-classic/*) —
-          # those live only on main. Restore them from main so the theme
-          # chrome translations this repo owns actually reach staging
-          # instead of silently falling back to whatever (or nothing) the
-          # content branch has for those paths.
-          git ls-files -z 'i18n/*/code.json' 'i18n/*/docusaurus-theme-classic/*' \
+          # translation files (docusaurus-theme-classic/*) — those live
+          # only on main. Restore them from main so the theme chrome
+          # translations this repo owns actually reach staging instead of
+          # silently falling back to whatever (or nothing) the content
+          # branch has for those paths.
+          git ls-files -z 'i18n/*/docusaurus-theme-classic/*' \
             | xargs -0 -r git checkout HEAD --
+
+          # code.json also carries Notion-generated, content-only
+          # translation keys that live only on the content branch. A blind
+          # `checkout HEAD` here would silently drop those on every build.
+          # Merge instead: keep content-only keys, let HEAD win any key
+          # this repo also defines.
+          git ls-files -z 'i18n/*/code.json' | while IFS= read -r -d '' f; do
+            jq -s '.[0] + .[1]' "$f" <(git show "HEAD:$f") > "$f.tmp" && mv "$f.tmp" "$f"
+          done
 
           # Validate content exists
           echo "🔍 Validating content..."

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -66,7 +66,7 @@ jobs:
 
             if [ "$SHOULD_DEPLOY" != "true" ]; then
               if [ "$BRANCH_NAME" = "main" ]; then
-                if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(src/|static/img/|docusaurus\.config\.ts$|sidebars\.ts$|package\.json$)'; then
+                if printf '%s\n' "$CHANGED_FILES" | grep -Eq '^(src/|static/img/|docusaurus\.config\.ts$|sidebars\.ts$|package\.json$|docs/|i18n/)'; then
                   SHOULD_DEPLOY="true"
                   REASON="main push includes code/config paths."
                 else

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -43,9 +43,33 @@ jobs:
           # `checkout HEAD` here would silently drop those on every build.
           # Merge instead: keep content-only keys, let HEAD win any key
           # this repo also defines.
+          #
+          # `jq -s` slurps every JSON document across BOTH input files into
+          # one flat array and blindly indexes [0]/[1] — it does not verify
+          # each file actually contributed exactly one object. An empty or
+          # `null` content file silently falls back to HEAD alone; a content
+          # file with two concatenated JSON documents silently drops HEAD
+          # entirely. Validate each side is exactly one JSON object before
+          # merging so malformed input fails the step instead of shipping a
+          # silently wrong catalog.
+          validate_single_json_object() {
+            local file="$1" label="$2" count
+            count=$(jq -s 'length' "$file" 2>/dev/null) || { echo "::error::$label: not valid JSON" >&2; return 1; }
+            if [ "$count" != "1" ]; then
+              echo "::error::$label: expected exactly 1 JSON document, found $count" >&2
+              return 1
+            fi
+            jq -e 'type == "object"' "$file" >/dev/null 2>&1 || { echo "::error::$label: root value is not a JSON object" >&2; return 1; }
+          }
+
           git ls-files -z 'i18n/*/code.json' | while IFS= read -r -d '' f; do
-            jq -s '.[0] + .[1]' "$f" <(git show "HEAD:$f") > "$f.tmp"
+            head_tmp=$(mktemp)
+            git show "HEAD:$f" > "$head_tmp"
+            validate_single_json_object "$f" "$f (content overlay)"
+            validate_single_json_object "$head_tmp" "HEAD:$f"
+            jq -s '.[0] + .[1]' "$f" "$head_tmp" > "$f.tmp"
             mv "$f.tmp" "$f"
+            rm -f "$head_tmp"
           done
 
           # Validate content exists

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -28,6 +28,16 @@ jobs:
           echo "📂 Checking out content files..."
           git checkout origin/content -- docs/ i18n/ static/images/
 
+          # The checkout above overlays i18n/ from the content branch,
+          # which does not carry this repo's hand-maintained theme
+          # translation files (code.json, docusaurus-theme-classic/*) —
+          # those live only on main. Restore them from main so the theme
+          # chrome translations this repo owns actually reach the test
+          # deployment instead of silently falling back to whatever (or
+          # nothing) the content branch has for those paths.
+          git ls-files -z 'i18n/*/code.json' 'i18n/*/docusaurus-theme-classic/*' \
+            | xargs -0 -r git checkout HEAD --
+
           # Validate content exists
           echo "🔍 Validating content..."
 

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -44,7 +44,8 @@ jobs:
           # Merge instead: keep content-only keys, let HEAD win any key
           # this repo also defines.
           git ls-files -z 'i18n/*/code.json' | while IFS= read -r -d '' f; do
-            jq -s '.[0] + .[1]' "$f" <(git show "HEAD:$f") > "$f.tmp" && mv "$f.tmp" "$f"
+            jq -s '.[0] + .[1]' "$f" <(git show "HEAD:$f") > "$f.tmp"
+            mv "$f.tmp" "$f"
           done
 
           # Validate content exists

--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -30,13 +30,22 @@ jobs:
 
           # The checkout above overlays i18n/ from the content branch,
           # which does not carry this repo's hand-maintained theme
-          # translation files (code.json, docusaurus-theme-classic/*) —
-          # those live only on main. Restore them from main so the theme
-          # chrome translations this repo owns actually reach the test
-          # deployment instead of silently falling back to whatever (or
-          # nothing) the content branch has for those paths.
-          git ls-files -z 'i18n/*/code.json' 'i18n/*/docusaurus-theme-classic/*' \
+          # translation files (docusaurus-theme-classic/*) — those live
+          # only on main. Restore them from main so the theme chrome
+          # translations this repo owns actually reach the test deployment
+          # instead of silently falling back to whatever (or nothing) the
+          # content branch has for those paths.
+          git ls-files -z 'i18n/*/docusaurus-theme-classic/*' \
             | xargs -0 -r git checkout HEAD --
+
+          # code.json also carries Notion-generated, content-only
+          # translation keys that live only on the content branch. A blind
+          # `checkout HEAD` here would silently drop those on every build.
+          # Merge instead: keep content-only keys, let HEAD win any key
+          # this repo also defines.
+          git ls-files -z 'i18n/*/code.json' | while IFS= read -r -d '' f; do
+            jq -s '.[0] + .[1]' "$f" <(git show "HEAD:$f") > "$f.tmp" && mv "$f.tmp" "$f"
+          done
 
           # Validate content exists
           echo "🔍 Validating content..."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -53,7 +53,8 @@ jobs:
             # catalog. Merge instead: keep content-only keys, let HEAD win
             # any key this repo also defines.
             git ls-files -z 'i18n/*/code.json' | while IFS= read -r -d '' f; do
-              jq -s '.[0] + .[1]' "$f" <(git show "HEAD:$f") > "$f.tmp" && mv "$f.tmp" "$f"
+              jq -s '.[0] + .[1]' "$f" <(git show "HEAD:$f") > "$f.tmp"
+              mv "$f.tmp" "$f"
             done
           else
             echo "has_i18n=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,6 +30,19 @@ jobs:
           if git checkout origin/content -- i18n/; then
             echo "has_i18n=true" >> "$GITHUB_OUTPUT"
             echo "✅ Loaded i18n content from origin/content."
+
+            # The checkout above overlays i18n/ from the content branch,
+            # which would silently discard any i18n/ files this PR itself
+            # modified (e.g. theme translation navbar.json/footer.json/
+            # code.json), letting locale tests pass without ever validating
+            # what the PR is actually proposing. Restore this PR's own
+            # versions of any i18n/ path it actually changed.
+            PR_I18N_CHANGES=$(git diff --name-only "$(git merge-base HEAD origin/main)" HEAD -- i18n/ || true)
+            if [ -n "$PR_I18N_CHANGES" ]; then
+              echo "Restoring PR-authored i18n files over content overlay:"
+              echo "$PR_I18N_CHANGES"
+              echo "$PR_I18N_CHANGES" | xargs -r git checkout HEAD --
+            fi
           else
             echo "has_i18n=false" >> "$GITHUB_OUTPUT"
             echo "⚠️ origin/content checkout failed. Locale-dependent tests will be skipped."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,17 +32,20 @@ jobs:
             echo "✅ Loaded i18n content from origin/content."
 
             # The checkout above overlays i18n/ from the content branch,
-            # which would silently discard any i18n/ files this PR itself
-            # modified (e.g. theme translation navbar.json/footer.json/
-            # code.json), letting locale tests pass without ever validating
-            # what the PR is actually proposing. Restore this PR's own
-            # versions of any i18n/ path it actually changed.
-            PR_I18N_CHANGES=$(git diff --name-only "$(git merge-base HEAD origin/main)" HEAD -- i18n/ || true)
-            if [ -n "$PR_I18N_CHANGES" ]; then
-              echo "Restoring PR-authored i18n files over content overlay:"
-              echo "$PR_I18N_CHANGES"
-              echo "$PR_I18N_CHANGES" | xargs -r git checkout HEAD --
-            fi
+            # which would silently discard the hand-maintained theme
+            # translation files this repo owns (code.json, docusaurus-
+            # theme-classic/*), letting locale tests pass against stale
+            # content-branch data instead of what's actually committed
+            # here. A prior version of this restore only looked at what
+            # the current ref changed relative to its merge-base with
+            # main, which is empty on a push to main itself (HEAD ==
+            # origin/main) and for any PR that doesn't touch i18n/ —
+            # so it silently did nothing on exactly the runs that matter
+            # most. Restore unconditionally instead: these paths are
+            # always supposed to come from the git-tracked ref being
+            # tested, never from content.
+            git ls-files -z 'i18n/*/code.json' 'i18n/*/docusaurus-theme-classic/*' \
+              | xargs -0 -r git checkout HEAD --
           else
             echo "has_i18n=false" >> "$GITHUB_OUTPUT"
             echo "⚠️ origin/content checkout failed. Locale-dependent tests will be skipped."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,19 +33,28 @@ jobs:
 
             # The checkout above overlays i18n/ from the content branch,
             # which would silently discard the hand-maintained theme
-            # translation files this repo owns (code.json, docusaurus-
-            # theme-classic/*), letting locale tests pass against stale
-            # content-branch data instead of what's actually committed
-            # here. A prior version of this restore only looked at what
-            # the current ref changed relative to its merge-base with
-            # main, which is empty on a push to main itself (HEAD ==
-            # origin/main) and for any PR that doesn't touch i18n/ —
-            # so it silently did nothing on exactly the runs that matter
-            # most. Restore unconditionally instead: these paths are
-            # always supposed to come from the git-tracked ref being
-            # tested, never from content.
-            git ls-files -z 'i18n/*/code.json' 'i18n/*/docusaurus-theme-classic/*' \
+            # translation files this repo owns (docusaurus-theme-classic/*),
+            # letting locale tests pass against stale content-branch data
+            # instead of what's actually committed here. A prior version of
+            # this restore only looked at what the current ref changed
+            # relative to its merge-base with main, which is empty on a push
+            # to main itself (HEAD == origin/main) and for any PR that
+            # doesn't touch i18n/ — so it silently did nothing on exactly
+            # the runs that matter most. Restore unconditionally instead:
+            # these paths are always supposed to come from the git-tracked
+            # ref being tested, never from content.
+            git ls-files -z 'i18n/*/docusaurus-theme-classic/*' \
               | xargs -0 -r git checkout HEAD --
+
+            # code.json also carries Notion-generated, content-only
+            # translation keys that live only on the content branch. A
+            # blind `checkout HEAD` here would silently drop those and let
+            # locale tests validate an unrealistic, content-key-free
+            # catalog. Merge instead: keep content-only keys, let HEAD win
+            # any key this repo also defines.
+            git ls-files -z 'i18n/*/code.json' | while IFS= read -r -d '' f; do
+              jq -s '.[0] + .[1]' "$f" <(git show "HEAD:$f") > "$f.tmp" && mv "$f.tmp" "$f"
+            done
           else
             echo "has_i18n=false" >> "$GITHUB_OUTPUT"
             echo "⚠️ origin/content checkout failed. Locale-dependent tests will be skipped."

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,9 +52,33 @@ jobs:
             # locale tests validate an unrealistic, content-key-free
             # catalog. Merge instead: keep content-only keys, let HEAD win
             # any key this repo also defines.
+            #
+            # `jq -s` slurps every JSON document across BOTH input files
+            # into one flat array and blindly indexes [0]/[1] — it does not
+            # verify each file actually contributed exactly one object. An
+            # empty or `null` content file silently falls back to HEAD
+            # alone; a content file with two concatenated JSON documents
+            # silently drops HEAD entirely. Validate each side is exactly
+            # one JSON object before merging so malformed input fails the
+            # step instead of shipping a silently wrong catalog.
+            validate_single_json_object() {
+              local file="$1" label="$2" count
+              count=$(jq -s 'length' "$file" 2>/dev/null) || { echo "::error::$label: not valid JSON" >&2; return 1; }
+              if [ "$count" != "1" ]; then
+                echo "::error::$label: expected exactly 1 JSON document, found $count" >&2
+                return 1
+              fi
+              jq -e 'type == "object"' "$file" >/dev/null 2>&1 || { echo "::error::$label: root value is not a JSON object" >&2; return 1; }
+            }
+
             git ls-files -z 'i18n/*/code.json' | while IFS= read -r -d '' f; do
-              jq -s '.[0] + .[1]' "$f" <(git show "HEAD:$f") > "$f.tmp"
+              head_tmp=$(mktemp)
+              git show "HEAD:$f" > "$head_tmp"
+              validate_single_json_object "$f" "$f (content overlay)"
+              validate_single_json_object "$head_tmp" "HEAD:$f"
+              jq -s '.[0] + .[1]' "$f" "$head_tmp" > "$f.tmp"
               mv "$f.tmp" "$f"
+              rm -f "$head_tmp"
             done
           else
             echo "has_i18n=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/translate-docs.yml
+++ b/.github/workflows/translate-docs.yml
@@ -58,7 +58,10 @@ jobs:
 
           # Remove the lines that ignore generated content directories and their associated comments
           # This preserves all other .gitignore updates from main while allowing commits to these dirs
-          sed -i '/^# Generated content (synced from content branch)$/d; /^# These directories are populated by checking out from the content branch$/d; /^\/docs\/$/d; /^\/i18n\/$/d; /^\/static\/images\/$/d' .gitignore
+          # The i18n negation block (theme JSON allowlist for es/pt) must also be stripped here,
+          # otherwise its /i18n/* rule keeps everything outside navbar.json/footer.json ignored
+          # on the content branch (e.g. code.json, translated doc pages never get committed).
+          sed -i '/^# Generated content (synced from content branch)$/d; /^# These directories are populated by checking out from the content branch$/d; /^\/docs\/$/d; /^\/i18n\/$/d; /^\/static\/images\/$/d; /^# Generated i18n content/,/^$/d' .gitignore
 
           # Only commit if .gitignore actually changed
           if ! git diff --quiet .gitignore; then

--- a/.gitignore
+++ b/.gitignore
@@ -59,8 +59,22 @@ assets/
 # Generated content (synced from content branch)
 # These directories are populated by checking out from the content branch
 /docs/
-/i18n/
 /static/images/
+
+# Generated i18n content — selectively un-ignore theme JSON for es/pt
+/i18n/*
+!/i18n/es/
+/i18n/es/*
+!/i18n/es/docusaurus-theme-classic/
+/i18n/es/docusaurus-theme-classic/*
+!/i18n/es/docusaurus-theme-classic/navbar.json
+!/i18n/es/docusaurus-theme-classic/footer.json
+!/i18n/pt/
+/i18n/pt/*
+!/i18n/pt/docusaurus-theme-classic/
+/i18n/pt/docusaurus-theme-classic/*
+!/i18n/pt/docusaurus-theme-classic/navbar.json
+!/i18n/pt/docusaurus-theme-classic/footer.json
 
 # Generated robots.txt (created at build time based on IS_PRODUCTION env var)
 /static/robots.txt

--- a/i18n/es/code.json
+++ b/i18n/es/code.json
@@ -365,7 +365,7 @@
     "description": "The default label used for the Danger admonition (:::danger)"
   },
   "theme.admonition.info": {
-    "message": "info",
+    "message": "información",
     "description": "The default label used for the Info admonition (:::info)"
   },
   "theme.admonition.note": {
@@ -373,7 +373,7 @@
     "description": "The default label used for the Note admonition (:::note)"
   },
   "theme.admonition.tip": {
-    "message": "tip",
+    "message": "consejo",
     "description": "The default label used for the Tip admonition (:::tip)"
   },
   "theme.admonition.warning": {

--- a/i18n/es/code.json
+++ b/i18n/es/code.json
@@ -10,124 +10,124 @@
     "message": "Preparación para el uso de CoMapeo"
   },
   "Understanding CoMapeo's Core Concepts and Functions": {
-    "message": "Nueva Página"
+    "message": "Comprender los Conceptos y Funciones Principales de CoMapeo"
   },
   "Getting Started Essentials": {
-    "message": "Nuevo título de sección"
+    "message": "Introducción y Elementos Esenciales"
   },
   "Gathering the Right Equipment for CoMapeo": {
     "message": "Reunir el Equipo Adecuado para CoMapeo"
   },
   "Device Setup and Maintenance for CoMapeo": {
-    "message": "Nueva Página"
+    "message": "Configuración y Mantenimiento de Dispositivos para CoMapeo"
   },
   "Installing CoMapeo & Onboarding": {
-    "message": "Nueva Página"
+    "message": "Instalación de CoMapeo e Incorporación"
   },
   "Initial Use and CoMapeo Settings": {
-    "message": "Nueva Página"
+    "message": "Uso Inicial y Configuración de CoMapeo"
   },
   "Uninstalling CoMapeo": {
     "message": "Desinstalar CoMapeo"
   },
   "Customizing CoMapeo": {
-    "message": "Nueva Palanca"
+    "message": "Personalización de CoMapeo"
   },
   "Organizing Key Materials for Projects": {
-    "message": "Nueva Página"
+    "message": "Organización de Materiales Clave para Proyectos"
   },
   "Building a Custom Categories Set": {
-    "message": "Nueva Página"
+    "message": "Crear un Conjunto de Categorías Personalizado"
   },
   "Building Custom Background Maps": {
-    "message": "Nueva Página"
+    "message": "Crear Mapas de Fondo Personalizados"
   },
   "Observations & Tracks": {
-    "message": "Nuevo título de sección"
+    "message": "Observaciones y Recorridos"
   },
   "Gathering Observations & Tracks": {
     "message": "Recopilación de observaciones"
   },
   "Creating a New Observation": {
-    "message": "Nueva Página"
+    "message": "Crear una Nueva Observación"
   },
   "Creating a New Track": {
-    "message": "Nueva Página"
+    "message": "Crear un Nuevo Recorrido"
   },
   "Reviewing Observations": {
     "message": "Revisión de observaciones"
   },
   "Exploring the Observations List": {
-    "message": "Nueva Página"
+    "message": "Explorar la Lista de Observaciones"
   },
   "Reviewing an Observation": {
-    "message": "Nueva Página"
+    "message": "Revisar una Observación"
   },
   "Editing Observations": {
-    "message": "Nueva Página"
+    "message": "Editar Observaciones"
   },
   "Data Privacy & Security": {
-    "message": "Nuevo título de sección"
+    "message": "Datos, Privacidad y Seguridad"
   },
   "Encryption and Security": {
-    "message": "Nueva Página"
+    "message": "Encriptación y Seguridad"
   },
   "Managing Data Privacy & Security": {
     "message": "Gestión de datos y privacidad"
   },
   "Using an App Passcode for Security": {
-    "message": "Nueva Página"
+    "message": "Usar un Código de Acceso para Seguridad"
   },
   "Adjusting Data Sharing and Privacy": {
-    "message": "Nueva Página"
+    "message": "Ajustar el Intercambio de Datos y la Privacidad"
   },
   "Mapping with Collaborators": {
-    "message": "Nueva Página"
+    "message": "Mapeo con Colaboradores"
   },
   "Managing Projects": {
     "message": "Gestión de proyectos"
   },
   "Understanding Projects": {
-    "message": "Nueva Página"
+    "message": "Comprender los Proyectos"
   },
   "Creating a New Project": {
-    "message": "Nueva Página"
+    "message": "Crear un Nuevo Proyecto"
   },
   "Changing Categories Set": {
-    "message": "Nueva Página"
+    "message": "Cambiar Conjunto de Categorías"
   },
   "Managing a Team": {
-    "message": "Nueva Página"
+    "message": "Gestionar un Equipo"
   },
   "Inviting Collaborators": {
-    "message": "Nueva Página"
+    "message": "Invitar Colaboradores"
   },
   "Ending a Project": {
-    "message": "Nueva Página"
+    "message": "Finalizar un Proyecto"
   },
   "Exchanging Project Data": {
     "message": "Intercambio de Datos del Proyecto"
   },
   "Understanding How Exchange Works": {
-    "message": "Nueva Página A"
+    "message": "Comprender Cómo Funciona el Intercambio"
   },
   "Using Exchange Offline": {
-    "message": "Nueva Página"
+    "message": "Usar Intercambio sin Conexión"
   },
   "Using a Remote Archive": {
-    "message": "Nueva Página"
+    "message": "Usar un Archivo Remoto"
   },
   "Moving Observations & Tracks Outside of CoMapeo": {
     "message": "Compartir observaciones fuera de CoMapeo"
   },
   "Sharing a Single Observation and Metadata": {
-    "message": "Nueva Página"
+    "message": "Compartir una Observación Individual y Metadatos"
   },
   "Exporting all Observations": {
-    "message": "Nueva Página"
+    "message": "Exportar Todas las Observaciones"
   },
   "Using Observations outside of CoMapeo": {
-    "message": "Nueva Página"
+    "message": "Usar Observaciones Fuera de CoMapeo"
   },
   "Miscellaneous": {
     "message": "Misceláneas"
@@ -139,49 +139,40 @@
     "message": "Glosario"
   },
   "Troubleshooting": {
-    "message": "Nueva Palanca"
+    "message": "Resolución de Problemas"
   },
   "Common Solutions": {
-    "message": "Nueva Página"
+    "message": "Soluciones Comunes"
   },
   "Troubleshooting: Setup and Customization": {
-    "message": "Nueva Página"
+    "message": "Resolución de Problemas: Configuración y Personalización"
   },
   "Troubleshooting:  Observations and Tracks": {
-    "message": "Nueva Página"
+    "message": "Resolución de Problemas: Observaciones y Recorridos"
   },
   "Troubleshooting: Data Privacy and Security": {
-    "message": "Nueva Página"
+    "message": "Resolución de Problemas: Privacidad de Datos y Seguridad"
   },
   "Troubleshooting: Mapping with Collaborators": {
-    "message": "Nueva Página"
+    "message": "Resolución de Problemas: Mapeo con Colaboradores"
   },
   "Troubleshooting: Moving Observations and Tracks outside of CoMapeo": {
-    "message": "Nueva Página"
-  },
-  "Elementos de contenido de prueba": {
-    "message": "Elementos de contenido de prueba"
-  },
-  "Testing links": {
-    "message": "Nueva Página"
-  },
-  "Understanding CoMapeo's Core Concepts and Functions": {
-    "message": "Nueva Página"
+    "message": "Resolución de Problemas: Mover Observaciones y Recorridos Fuera de CoMapeo"
   },
   "Installing CoMapeo and Onboarding": {
-    "message": "Nueva Página"
+    "message": "Instalación de CoMapeo e Incorporación"
   },
   "Planning and Preparing for a Project": {
-    "message": "Nueva Página"
+    "message": "Planificación y Preparación para un Proyecto"
   },
   "Observations and Tracks": {
-    "message": "Nuevo título de sección"
+    "message": "Observaciones y Recorridos"
   },
   "Gathering Observations and Tracks": {
     "message": "Recopilación de observaciones"
   },
   "Data Privacy and Security": {
-    "message": "Nuevo título de sección"
+    "message": "Privacidad de Datos y Seguridad"
   },
   "Managing Data Privacy and Security": {
     "message": "Gestión de datos y privacidad"
@@ -197,5 +188,376 @@
   },
   "CLI Reference": {
     "message": "Referencia de CLI"
+  },
+  "Conversational Guidance": {
+    "message": "Orientación Conversacional",
+    "description": "Feature title for voice-enabled QA bots section"
+  },
+  "Get instant voice assistance through our documentation bots that listen to your questions and respond with precise answers in real-time.": {
+    "message": "Obtén asistencia de voz instantánea a través de nuestros bots de documentación que escuchan tus preguntas y responden con respuestas precisas en tiempo real.",
+    "description": "Description for voice-enabled QA bots section"
+  },
+  "Map in Any Language": {
+    "message": "Mapea en Cualquier Idioma",
+    "description": "Feature title for multi-lingual documentation section"
+  },
+  "Access CoMapeo documentation in multiple languages, ensuring every team member can learn and contribute regardless of their native tongue.": {
+    "message": "Accede a la documentación de CoMapeo en varios idiomas, asegurando que cada miembro del equipo pueda aprender y contribuir independientemente de su lengua materna.",
+    "description": "Description for multi-lingual documentation section"
+  },
+  "Your Mapping Journey Starts Here": {
+    "message": "Tu Viaje de Mapeo Comienza Aquí",
+    "description": "Feature title for comprehensive learning hub section"
+  },
+  "Everything you need to master the CoMapeo platform, from beginner tutorials to advanced techniques, all in one centralized knowledge center.": {
+    "message": "Todo lo que necesitas para dominar la plataforma CoMapeo, desde tutoriales para principiantes hasta técnicas avanzadas, todo en un centro de conocimiento centralizado.",
+    "description": "Description for comprehensive learning hub section"
+  },
+  "theme.docs.DocCard.categoryDescription.plurals": {
+    "message": "1 artículo|{count} artículos",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "Idiomas",
+    "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.ErrorPageContent.title": {
+    "message": "Esta página ha fallado.",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "Volver al principio",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.archive.title": {
+    "message": "Archivo",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "Archivo",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "Navegación por la página de la lista de blogs ",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "Entradas más recientes",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "Entradas más antiguas",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "Barra de paginación de publicaciones del blog",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "Publicación más reciente",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "Publicación más antigua",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "Ver Todas las Etiquetas",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.colorToggle.ariaLabel.mode.system": {
+    "message": "modo del sistema",
+    "description": "The name for the system color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.light": {
+    "message": "modo claro",
+    "description": "The name for the light color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.dark": {
+    "message": "modo oscuro",
+    "description": "The name for the dark color mode"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "Cambiar entre modo oscuro y claro (actualmente {mode})",
+    "description": "The ARIA label for the color mode toggle"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "Rastro de navegación",
+    "description": "The ARIA label for the breadcrumbs"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "Página del documento",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "Anterior",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "Siguiente",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "Un documento etiquetado|{count} documentos etiquetados",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged} con \"{tagName}\"",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "Versión: {versionLabel}"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "Esta es la documentación sin publicar para {siteTitle}, versión {versionLabel}.",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "Esta es la documentación para {siteTitle} {versionLabel}, que ya no se mantiene activamente.",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "Para la documentación actualizada, vea {latestVersionLink} ({versionLabel}).",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "última versión",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "Enlace directo al {heading}",
+    "description": "Title for link to heading"
+  },
+  "theme.common.editThisPage": {
+    "message": "Editar esta página",
+    "description": "The link label to edit the current page"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": " en {date}",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": " por {user}",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "Última actualización{atDate}{byUser}",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "Versiones",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.NotFound.title": {
+    "message": "Página No Encontrada",
+    "description": "The title of the 404 page"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "Etiquetas:",
+    "description": "The label alongside a tag list"
+  },
+  "theme.admonition.caution": {
+    "message": "precaución",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.admonition.danger": {
+    "message": "peligro",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "info",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.note": {
+    "message": "nota",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "tip",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.warning": {
+    "message": "aviso",
+    "description": "The default label used for the Warning admonition (:::warning)"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "Cerrar",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "Navegación de publicaciones recientes",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.DocSidebarItem.expandCategoryAriaLabel": {
+    "message": "Ampliar la categoría '{label}' de la barra lateral",
+    "description": "The ARIA label to expand the sidebar category"
+  },
+  "theme.DocSidebarItem.collapseCategoryAriaLabel": {
+    "message": "Colapsar categoría '{label}' de la barra lateral",
+    "description": "The ARIA label to collapse the sidebar category"
+  },
+  "theme.IconExternalLink.ariaLabel": {
+    "message": "(se abre en una nueva pestaña)",
+    "description": "The ARIA label for the external link icon"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "Principal",
+    "description": "The ARIA label for the main navigation"
+  },
+  "theme.NotFound.p1": {
+    "message": "No pudimos encontrar lo que buscaba.",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "Comuníquese con el dueño del sitio que le proporcionó la URL original y hágale saber que su vínculo está roto.",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "En esta página",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "Lectura de un minuto|{readingTime} min de lectura",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.post.readMore": {
+    "message": "Leer Más",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.readMoreLabel": {
+    "message": "Leer más acerca de {title}",
+    "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "Copiar",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "Copiado",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "Copiar código",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.wordWrapToggle": {
+    "message": "Alternar ajuste de palabras",
+    "description": "The title attribute for toggle word wrapping button of code block lines"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "Página de Inicio",
+    "description": "The ARIA label for the home page in the breadcrumbs"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "Colapsar barra lateral",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "Colapsar barra lateral",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "Barra lateral de Documentos",
+    "description": "The ARIA label for the sidebar navigation"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "Cerrar barra de lateral",
+    "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← Volver al menú principal",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "Alternar barra lateral",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.expandAriaLabel": {
+    "message": "Expandir el menú desplegable",
+    "description": "The ARIA label of the button to expand the mobile dropdown navbar item"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.collapseAriaLabel": {
+    "message": "Contraer el menú desplegable",
+    "description": "The ARIA label of the button to collapse the mobile dropdown navbar item"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "Expandir barra lateral",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "Expandir barra lateral",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.IdealImageMessage.loading": {
+    "message": "Cargando...",
+    "description": "When the full-scale image is loading"
+  },
+  "theme.IdealImageMessage.load": {
+    "message": "Click para recargar{sizeMessage}",
+    "description": "To prompt users to load the full image. sizeMessage is a parenthesized size figure."
+  },
+  "theme.IdealImageMessage.offline": {
+    "message": "Tu navegador está desconectado. Imagen no cargada",
+    "description": "When the user is viewing an offline document"
+  },
+  "theme.IdealImageMessage.404error": {
+    "message": "404. Imagen no encontrada",
+    "description": "When the image is not found"
+  },
+  "theme.IdealImageMessage.error": {
+    "message": "Error. Click para recargar",
+    "description": "When the image fails to load for unknown error"
+  },
+  "theme.blog.post.plurals": {
+    "message": "Una publicación|{count} publicaciones",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} etiquetados con \"{tagName}\"",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.blog.author.pageTitle": {
+    "message": "{authorName} - {nPosts}",
+    "description": "The title of the page for a blog author"
+  },
+  "theme.blog.authorsList.pageTitle": {
+    "message": "Autores",
+    "description": "The title of the authors page"
+  },
+  "theme.blog.authorsList.viewAll": {
+    "message": "Ver Todos los Autores",
+    "description": "The label of the link targeting the blog authors page"
+  },
+  "theme.blog.author.noPosts": {
+    "message": "Este autor aún no ha escrito ninguna publicación.",
+    "description": "The text for authors with 0 blog post"
+  },
+  "theme.contentVisibility.unlistedBanner.title": {
+    "message": "Página sin clasificar",
+    "description": "The unlisted content banner title"
+  },
+  "theme.contentVisibility.unlistedBanner.message": {
+    "message": "Esta página está sin clasificar. Los motores de búsqueda no la indexaran, y solo los usuarios con el enlace directo podrán acceder a esta.",
+    "description": "The unlisted content banner message"
+  },
+  "theme.contentVisibility.draftBanner.title": {
+    "message": "Página de borrador",
+    "description": "The draft content banner title"
+  },
+  "theme.contentVisibility.draftBanner.message": {
+    "message": "Esta página es un borrador. Solo será visible en desarrollo y se excluirá de la compilación de producción.",
+    "description": "The draft content banner message"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "Intente de nuevo",
+    "description": "The label of the button to try again rendering when the React error boundary captures an error"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "Saltar al contenido principal",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "Etiquetas",
+    "description": "The title of the tag list page"
   }
 }

--- a/i18n/es/code.json
+++ b/i18n/es/code.json
@@ -559,5 +559,17 @@
   "theme.tags.tagsPageTitle": {
     "message": "Etiquetas",
     "description": "The title of the tag list page"
+  },
+  "theme.PwaReloadPopup.closeButtonAriaLabel": {
+    "message": "Cerrar",
+    "description": "The ARIA label for close button of PWA reload popup"
+  },
+  "theme.PwaReloadPopup.info": {
+    "message": "Nueva versión disponible",
+    "description": "The text used in PWA reload popup"
+  },
+  "theme.PwaReloadPopup.refreshButtonText": {
+    "message": "Actualizar",
+    "description": "The text used for PWA reload button"
   }
 }

--- a/i18n/es/code.json
+++ b/i18n/es/code.json
@@ -238,7 +238,7 @@
     "description": "The page & hero description of the blog archive page"
   },
   "theme.blog.paginator.navAriaLabel": {
-    "message": "Navegación por la página de la lista de blogs ",
+    "message": "Navegación por la página de la lista de blogs",
     "description": "The ARIA label for the blog pagination"
   },
   "theme.blog.paginator.newerEntries": {
@@ -461,7 +461,7 @@
     "description": "The ARIA label for the sidebar navigation"
   },
   "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
-    "message": "Cerrar barra de lateral",
+    "message": "Cerrar barra lateral",
     "description": "The ARIA label for close button of mobile sidebar"
   },
   "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
@@ -493,7 +493,7 @@
     "description": "When the full-scale image is loading"
   },
   "theme.IdealImageMessage.load": {
-    "message": "Click para recargar{sizeMessage}",
+    "message": "Haz clic para cargar{sizeMessage}",
     "description": "To prompt users to load the full image. sizeMessage is a parenthesized size figure."
   },
   "theme.IdealImageMessage.offline": {
@@ -505,7 +505,7 @@
     "description": "When the image is not found"
   },
   "theme.IdealImageMessage.error": {
-    "message": "Error. Click para recargar",
+    "message": "Error. Haz clic para recargar",
     "description": "When the image fails to load for unknown error"
   },
   "theme.blog.post.plurals": {
@@ -537,7 +537,7 @@
     "description": "The unlisted content banner title"
   },
   "theme.contentVisibility.unlistedBanner.message": {
-    "message": "Esta página está sin clasificar. Los motores de búsqueda no la indexaran, y solo los usuarios con el enlace directo podrán acceder a esta.",
+    "message": "Esta página está sin clasificar. Los motores de búsqueda no la indexarán, y solo los usuarios con el enlace directo podrán acceder a esta.",
     "description": "The unlisted content banner message"
   },
   "theme.contentVisibility.draftBanner.title": {

--- a/i18n/es/docusaurus-theme-classic/footer.json
+++ b/i18n/es/docusaurus-theme-classic/footer.json
@@ -1,0 +1,106 @@
+{
+  "links.title.Awana Digital": {
+    "message": "Awana Digital",
+    "description": "Footer section title: Awana Digital"
+  },
+  "links.Awana Digital.Website": {
+    "message": "Sitio web",
+    "description": "Footer link label: Website"
+  },
+  "links.Awana Digital.Discord": {
+    "message": "Discord",
+    "description": "Footer link label: Discord"
+  },
+  "links.Awana Digital.Bluesky": {
+    "message": "Bluesky",
+    "description": "Footer link label: Bluesky"
+  },
+  "links.Awana Digital.Blog": {
+    "message": "Blog",
+    "description": "Footer link label: Blog"
+  },
+  "links.title.CoMapeo": {
+    "message": "CoMapeo",
+    "description": "Footer section title: CoMapeo"
+  },
+  "links.CoMapeo.Website": {
+    "message": "Sitio web",
+    "description": "Footer link label: Website"
+  },
+  "links.CoMapeo.CoMapeo Mobile GitHub": {
+    "message": "GitHub de CoMapeo Mobile",
+    "description": "Footer link label: CoMapeo Mobile GitHub"
+  },
+  "links.CoMapeo.CoMapeo Desktop GitHub": {
+    "message": "GitHub de CoMapeo Desktop",
+    "description": "Footer link label: CoMapeo Desktop GitHub"
+  },
+  "links.title.More": {
+    "message": "Más",
+    "description": "Footer section title: More"
+  },
+  "links.More.PlayStore": {
+    "message": "PlayStore",
+    "description": "Footer link label: PlayStore"
+  },
+  "links.More.GitHub": {
+    "message": "GitHub",
+    "description": "Footer link label: GitHub"
+  },
+  "links.More.Earth Defenders Toolkit": {
+    "message": "Earth Defenders Toolkit",
+    "description": "Footer link label: Earth Defenders Toolkit"
+  },
+  "copyright": {
+    "message": "Hecho con ❤️ por Awana Digital - 2026",
+    "description": "The footer copyright"
+  },
+  "link.title.Awana Digital": {
+    "message": "Awana Digital",
+    "description": "The title of the footer links column with title=Awana Digital in the footer"
+  },
+  "link.title.CoMapeo": {
+    "message": "CoMapeo",
+    "description": "The title of the footer links column with title=CoMapeo in the footer"
+  },
+  "link.title.More": {
+    "message": "Más",
+    "description": "The title of the footer links column with title=More in the footer"
+  },
+  "link.item.label.Website": {
+    "message": "Sitio web",
+    "description": "The label of footer link with label=Website linking to https://comapeo.app"
+  },
+  "link.item.label.Discord": {
+    "message": "Discord",
+    "description": "The label of footer link with label=Discord linking to https://discord.gg/NtZgtAjj"
+  },
+  "link.item.label.Bluesky": {
+    "message": "Bluesky",
+    "description": "The label of footer link with label=Bluesky linking to https://bsky.app/profile/awana.digital"
+  },
+  "link.item.label.Blog": {
+    "message": "Blog",
+    "description": "The label of footer link with label=Blog linking to https://awana.digital/blog"
+  },
+  "link.item.label.CoMapeo Mobile GitHub": {
+    "message": "GitHub de CoMapeo Mobile",
+    "description": "The label of footer link with label=CoMapeo Mobile GitHub linking to https://github.com/digidem/comapeo-docs"
+  },
+  "link.item.label.CoMapeo Desktop GitHub": {
+    "message": "GitHub de CoMapeo Desktop",
+    "description": "The label of footer link with label=CoMapeo Desktop GitHub linking to https://github.com/digidem/comapeo-docs"
+  },
+  "link.item.label.PlayStore": {
+    "message": "PlayStore",
+    "description": "The label of footer link with label=PlayStore linking to https://play.google.com/store/apps/details?id=com.comapeo"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/digidem/comapeo-docs"
+  },
+  "link.item.label.Earth Defenders Toolkit": {
+    "message": "Earth Defenders Toolkit",
+    "description": "The label of footer link with label=Earth Defenders Toolkit linking to https://www.earthdefenderstoolkit.com/"
+  }
+}

--- a/i18n/es/docusaurus-theme-classic/navbar.json
+++ b/i18n/es/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,14 @@
+{
+  "item.label.Documentation": {
+    "message": "Documentación",
+    "description": "Navbar item with label Documentation"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  },
+  "logo.alt": {
+    "message": "CoMapeo",
+    "description": "The alt text of navbar logo"
+  }
+}

--- a/i18n/pt/code.json
+++ b/i18n/pt/code.json
@@ -159,7 +159,6 @@
   "Troubleshooting: Moving Observations and Tracks outside of CoMapeo": {
     "message": "Resolução de Problemas: Movendo Observações e Percursos Fora do CoMapeo"
   },
-
   "Installing CoMapeo and Onboarding": {
     "message": "Instalação do CoMapeo e Integração"
   },
@@ -560,5 +559,17 @@
   "theme.tags.tagsPageTitle": {
     "message": "Etiquetas",
     "description": "The title of the tag list page"
+  },
+  "theme.PwaReloadPopup.closeButtonAriaLabel": {
+    "message": "Fechar",
+    "description": "The ARIA label for close button of PWA reload popup"
+  },
+  "theme.PwaReloadPopup.info": {
+    "message": "Nova versão disponível",
+    "description": "The text used in PWA reload popup"
+  },
+  "theme.PwaReloadPopup.refreshButtonText": {
+    "message": "Atualizar",
+    "description": "The text used for PWA reload button"
   }
 }

--- a/i18n/pt/code.json
+++ b/i18n/pt/code.json
@@ -7,130 +7,130 @@
     "message": "Introdução"
   },
   "Preparing to Use CoMapeo": {
-    "message": "Preparando para usar do CoMapeo (Mobile)"
+    "message": "Preparando para Usar o CoMapeo"
   },
   "Understanding CoMapeo's Core Concepts and Functions": {
-    "message": "Nova Página"
+    "message": "Compreendendo os Conceitos e Funções Principais do CoMapeo"
   },
   "Getting Started Essentials": {
-    "message": "Novo título da seção"
+    "message": "Introdução e Elementos Essenciais"
   },
   "Gathering the Right Equipment for CoMapeo": {
     "message": "Reunindo o Equipamento Certo para o CoMapeo"
   },
   "Device Setup and Maintenance for CoMapeo": {
-    "message": "Nova Página"
+    "message": "Configuração e Manutenção de Dispositivos para CoMapeo"
   },
   "Installing CoMapeo & Onboarding": {
-    "message": "Nova Página"
+    "message": "Instalação do CoMapeo e Integração"
   },
   "Initial Use and CoMapeo Settings": {
-    "message": "Nova Página"
+    "message": "Uso Inicial e Configurações do CoMapeo"
   },
   "Uninstalling CoMapeo": {
-    "message": "Nova Página"
+    "message": "Desinstalando o CoMapeo"
   },
   "Customizing CoMapeo": {
-    "message": "Novo Alternar"
+    "message": "Personalizando o CoMapeo"
   },
   "Organizing Key Materials for Projects": {
-    "message": "Nova Página"
+    "message": "Organizando Materiais Essenciais para Projetos"
   },
   "Building a Custom Categories Set": {
-    "message": "Nova Página"
+    "message": "Criando um Conjunto de Categorias Personalizado"
   },
   "Building Custom Background Maps": {
-    "message": "Nova Página"
+    "message": "Criando Mapas de Fundo Personalizados"
   },
   "Observations & Tracks": {
-    "message": "Novo título da seção"
+    "message": "Observações e Percursos"
   },
   "Gathering Observations & Tracks": {
     "message": "Coletando Observações"
   },
   "Creating a New Observation": {
-    "message": "Nova Página"
+    "message": "Criando uma Nova Observação"
   },
   "Creating a New Track": {
-    "message": "Nova Página"
+    "message": "Criando um Novo Percurso"
   },
   "Reviewing Observations": {
     "message": "Revisando Observações"
   },
   "Exploring the Observations List": {
-    "message": "Nova Página"
+    "message": "Explorando a Lista de Observações"
   },
   "Reviewing an Observation": {
-    "message": "Nova Página"
+    "message": "Revisando uma Observação"
   },
   "Editing Observations": {
-    "message": "Nova Página"
+    "message": "Editando Observações"
   },
   "Data Privacy & Security": {
-    "message": "Novo título da seção"
+    "message": "Dados, Privacidade e Segurança"
   },
   "Encryption and Security": {
-    "message": "Nova Página"
+    "message": "Criptografia e Segurança"
   },
   "Managing Data Privacy & Security": {
     "message": "Gerenciamento de dados e privacidade"
   },
   "Using an App Passcode for Security": {
-    "message": "Nova Página"
+    "message": "Usando um Código de Acesso para Segurança"
   },
   "Adjusting Data Sharing and Privacy": {
-    "message": "Nova Página"
+    "message": "Ajustando o Compartilhamento de Dados e Privacidade"
   },
   "Mapping with Collaborators": {
-    "message": "Nova Página"
+    "message": "Mapeamento com Colaboradores"
   },
   "Managing Projects": {
     "message": "Gerenciando Projetos"
   },
   "Understanding Projects": {
-    "message": "Nova Página"
+    "message": "Compreendendo os Projetos"
   },
   "Creating a New Project": {
-    "message": "Nova Página"
+    "message": "Criando um Novo Projeto"
   },
   "Changing Categories Set": {
-    "message": "Nova Página"
+    "message": "Alterando Conjunto de Categorias"
   },
   "Managing a Team": {
-    "message": "Nova Página"
+    "message": "Gerenciando uma Equipe"
   },
   "Inviting Collaborators": {
-    "message": "Nova Página"
+    "message": "Convidando Colaboradores"
   },
   "Ending a Project": {
-    "message": "Nova Página"
+    "message": "Finalizando um Projeto"
   },
   "Exchanging Project Data": {
     "message": "Troca de Dados do Projeto"
   },
   "Understanding How Exchange Works": {
-    "message": "Nova Página A"
+    "message": "Compreendendo Como Funciona a Troca"
   },
   "Using Exchange Offline": {
-    "message": "Nova Página"
+    "message": "Usando a Troca Offline"
   },
   "Using a Remote Archive": {
-    "message": "Nova Página"
+    "message": "Usando um Arquivo Remoto"
   },
   "Moving Observations & Tracks Outside of CoMapeo": {
     "message": "Compartilhando observações fora do CoMapeo"
   },
   "Sharing a Single Observation and Metadata": {
-    "message": "Nova Página"
+    "message": "Compartilhando uma Observação Individual e Metadados"
   },
   "Exporting all Observations": {
-    "message": "Nova Página"
+    "message": "Exportando Todas as Observações"
   },
   "Using Observations outside of CoMapeo": {
-    "message": "Nova Página"
+    "message": "Usando Observações Fora do CoMapeo"
   },
   "Miscellaneous": {
-    "message": "Variado"
+    "message": "Diversos"
   },
   "FAQ": {
     "message": "Perguntas frequentes"
@@ -142,46 +142,38 @@
     "message": "Resolução de Problemas"
   },
   "Common Solutions": {
-    "message": "Nova Página"
+    "message": "Soluções Comuns"
   },
   "Troubleshooting: Setup and Customization": {
-    "message": "Nova Página"
+    "message": "Resolução de Problemas: Configuração e Personalização"
   },
   "Troubleshooting:  Observations and Tracks": {
-    "message": "Nova Página"
+    "message": "Resolução de Problemas: Observações e Percursos"
   },
   "Troubleshooting: Data Privacy and Security": {
-    "message": "Nova Página"
+    "message": "Resolução de Problemas: Privacidade de Dados e Segurança"
   },
   "Troubleshooting: Mapping with Collaborators": {
-    "message": "Nova Página"
+    "message": "Resolução de Problemas: Mapeamento com Colaboradores"
   },
   "Troubleshooting: Moving Observations and Tracks outside of CoMapeo": {
-    "message": "Nova Página"
+    "message": "Resolução de Problemas: Movendo Observações e Percursos Fora do CoMapeo"
   },
-  "Elementos de Conteúdo de Teste": {
-    "message": "Elementos de Conteúdo de Teste"
-  },
-  "Testing links": {
-    "message": "Nova Página"
-  },
-  "Understanding CoMapeo's Core Concepts and Functions": {
-    "message": "Nova Página"
-  },
+
   "Installing CoMapeo and Onboarding": {
-    "message": "Nova Página"
+    "message": "Instalação do CoMapeo e Integração"
   },
   "Planning and Preparing for a Project": {
-    "message": "Nova Página"
+    "message": "Planejamento e Preparação para um Projeto"
   },
   "Observations and Tracks": {
-    "message": "Novo título da seção"
+    "message": "Observações e Percursos"
   },
   "Gathering Observations and Tracks": {
     "message": "Coletando Observações"
   },
   "Data Privacy and Security": {
-    "message": "Novo título da seção"
+    "message": "Privacidade de Dados e Segurança"
   },
   "Managing Data Privacy and Security": {
     "message": "Gerenciamento de dados e privacidade"
@@ -197,5 +189,376 @@
   },
   "CLI Reference": {
     "message": "Referência de CLI"
+  },
+  "Conversational Guidance": {
+    "message": "Orientação Conversacional",
+    "description": "Feature title for voice-enabled QA bots section"
+  },
+  "Get instant voice assistance through our documentation bots that listen to your questions and respond with precise answers in real-time.": {
+    "message": "Obtenha assistência de voz instantânea através dos nossos bots de documentação que ouvem suas perguntas e respondem com respostas precisas em tempo real.",
+    "description": "Description for voice-enabled QA bots section"
+  },
+  "Map in Any Language": {
+    "message": "Mapeie em Qualquer Idioma",
+    "description": "Feature title for multi-lingual documentation section"
+  },
+  "Access CoMapeo documentation in multiple languages, ensuring every team member can learn and contribute regardless of their native tongue.": {
+    "message": "Acesse a documentação do CoMapeo em vários idiomas, garantindo que cada membro da equipe possa aprender e contribuir independentemente de sua língua nativa.",
+    "description": "Description for multi-lingual documentation section"
+  },
+  "Your Mapping Journey Starts Here": {
+    "message": "Sua Jornada de Mapeamento Começa Aqui",
+    "description": "Feature title for comprehensive learning hub section"
+  },
+  "Everything you need to master the CoMapeo platform, from beginner tutorials to advanced techniques, all in one centralized knowledge center.": {
+    "message": "Tudo o que você precisa para dominar a plataforma CoMapeo, desde tutoriais para iniciantes até técnicas avançadas, tudo em um centro de conhecimento centralizado.",
+    "description": "Description for comprehensive learning hub section"
+  },
+  "theme.docs.DocCard.categoryDescription.plurals": {
+    "message": "1 item|{count} itens",
+    "description": "The default description for a category card in the generated index about how many items this category includes"
+  },
+  "theme.navbar.mobileLanguageDropdown.label": {
+    "message": "Línguas",
+    "description": "The label for the mobile language switcher dropdown"
+  },
+  "theme.ErrorPageContent.title": {
+    "message": "Esta página deu erro.",
+    "description": "The title of the fallback page when the page crashed"
+  },
+  "theme.BackToTopButton.buttonAriaLabel": {
+    "message": "Voltar para o topo",
+    "description": "The ARIA label for the back to top button"
+  },
+  "theme.blog.archive.title": {
+    "message": "Arquivo",
+    "description": "The page & hero title of the blog archive page"
+  },
+  "theme.blog.archive.description": {
+    "message": "Arquivo",
+    "description": "The page & hero description of the blog archive page"
+  },
+  "theme.blog.paginator.navAriaLabel": {
+    "message": "Navegação da página de listagem do blog",
+    "description": "The ARIA label for the blog pagination"
+  },
+  "theme.blog.paginator.newerEntries": {
+    "message": "Publicações mais recentes",
+    "description": "The label used to navigate to the newer blog posts page (previous page)"
+  },
+  "theme.blog.paginator.olderEntries": {
+    "message": "Publicações mais antigas",
+    "description": "The label used to navigate to the older blog posts page (next page)"
+  },
+  "theme.blog.post.paginator.navAriaLabel": {
+    "message": "Navegação da página de publicação do blog",
+    "description": "The ARIA label for the blog posts pagination"
+  },
+  "theme.blog.post.paginator.newerPost": {
+    "message": "Publicação mais recente",
+    "description": "The blog post button label to navigate to the newer/previous post"
+  },
+  "theme.blog.post.paginator.olderPost": {
+    "message": "Publicação mais antiga",
+    "description": "The blog post button label to navigate to the older/next post"
+  },
+  "theme.tags.tagsPageLink": {
+    "message": "Ver todas as etiquetas",
+    "description": "The label of the link targeting the tag list page"
+  },
+  "theme.colorToggle.ariaLabel.mode.system": {
+    "message": "modo do sistema",
+    "description": "The name for the system color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.light": {
+    "message": "modo claro",
+    "description": "The name for the light color mode"
+  },
+  "theme.colorToggle.ariaLabel.mode.dark": {
+    "message": "modo escuro",
+    "description": "The name for the dark color mode"
+  },
+  "theme.colorToggle.ariaLabel": {
+    "message": "Mudar entre modo claro e escuro ({mode} está ativo)",
+    "description": "The ARIA label for the color mode toggle"
+  },
+  "theme.docs.breadcrumbs.navAriaLabel": {
+    "message": "Trilha",
+    "description": "The ARIA label for the breadcrumbs"
+  },
+  "theme.docs.paginator.navAriaLabel": {
+    "message": "Páginas de documento",
+    "description": "The ARIA label for the docs pagination"
+  },
+  "theme.docs.paginator.previous": {
+    "message": "Anterior",
+    "description": "The label used to navigate to the previous doc"
+  },
+  "theme.docs.paginator.next": {
+    "message": "Próxima",
+    "description": "The label used to navigate to the next doc"
+  },
+  "theme.docs.tagDocListPageTitle.nDocsTagged": {
+    "message": "Um documento marcado|{count} documentos marcados",
+    "description": "Pluralized label for \"{count} docs tagged\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.docs.tagDocListPageTitle": {
+    "message": "{nDocsTagged} com \"{tagName}\"",
+    "description": "The title of the page for a docs tag"
+  },
+  "theme.docs.versionBadge.label": {
+    "message": "Versão: {versionLabel}"
+  },
+  "theme.docs.versions.unreleasedVersionLabel": {
+    "message": "Esta é uma documentação não lançada da versão {versionLabel} para {siteTitle}.",
+    "description": "The label used to tell the user that he's browsing an unreleased doc version"
+  },
+  "theme.docs.versions.unmaintainedVersionLabel": {
+    "message": "Esta é a documentação para {siteTitle} {versionLabel}, que não é mais mantida ativamente.",
+    "description": "The label used to tell the user that he's browsing an unmaintained doc version"
+  },
+  "theme.docs.versions.latestVersionSuggestionLabel": {
+    "message": "Para a documentação atualizada, consulte a {latestVersionLink} ({versionLabel}).",
+    "description": "The label used to tell the user to check the latest version"
+  },
+  "theme.docs.versions.latestVersionLinkLabel": {
+    "message": "versão mais recente",
+    "description": "The label used for the latest version suggestion link label"
+  },
+  "theme.common.editThisPage": {
+    "message": "Editar esta página",
+    "description": "The link label to edit the current page"
+  },
+  "theme.common.headingLinkTitle": {
+    "message": "Link direto para {heading}",
+    "description": "Title for link to heading"
+  },
+  "theme.lastUpdated.atDate": {
+    "message": " em {date}",
+    "description": "The words used to describe on which date a page has been last updated"
+  },
+  "theme.lastUpdated.byUser": {
+    "message": " por {user}",
+    "description": "The words used to describe by who the page has been last updated"
+  },
+  "theme.lastUpdated.lastUpdatedAtBy": {
+    "message": "Última atualização{atDate}{byUser}",
+    "description": "The sentence used to display when a page has been last updated, and by who"
+  },
+  "theme.navbar.mobileVersionsDropdown.label": {
+    "message": "Versões",
+    "description": "The label for the navbar versions dropdown on mobile view"
+  },
+  "theme.NotFound.title": {
+    "message": "Página não encontrada",
+    "description": "The title of the 404 page"
+  },
+  "theme.tags.tagsListLabel": {
+    "message": "Etiquetas:",
+    "description": "The label alongside a tag list"
+  },
+  "theme.admonition.caution": {
+    "message": "cuidado",
+    "description": "The default label used for the Caution admonition (:::caution)"
+  },
+  "theme.admonition.danger": {
+    "message": "perigo",
+    "description": "The default label used for the Danger admonition (:::danger)"
+  },
+  "theme.admonition.info": {
+    "message": "informação",
+    "description": "The default label used for the Info admonition (:::info)"
+  },
+  "theme.admonition.note": {
+    "message": "observação",
+    "description": "The default label used for the Note admonition (:::note)"
+  },
+  "theme.admonition.tip": {
+    "message": "dica",
+    "description": "The default label used for the Tip admonition (:::tip)"
+  },
+  "theme.admonition.warning": {
+    "message": "aviso",
+    "description": "The default label used for the Warning admonition (:::warning)"
+  },
+  "theme.AnnouncementBar.closeButtonAriaLabel": {
+    "message": "Fechar",
+    "description": "The ARIA label for close button of announcement bar"
+  },
+  "theme.blog.sidebar.navAriaLabel": {
+    "message": "Navegação das publicações recentes do blog",
+    "description": "The ARIA label for recent posts in the blog sidebar"
+  },
+  "theme.DocSidebarItem.expandCategoryAriaLabel": {
+    "message": "Expandir a categoria '{label}'",
+    "description": "The ARIA label to expand the sidebar category"
+  },
+  "theme.DocSidebarItem.collapseCategoryAriaLabel": {
+    "message": "Recolher a categoria '{label}'",
+    "description": "The ARIA label to collapse the sidebar category"
+  },
+  "theme.IconExternalLink.ariaLabel": {
+    "message": "(abre em nova aba)",
+    "description": "The ARIA label for the external link icon"
+  },
+  "theme.NavBar.navAriaLabel": {
+    "message": "Navegação principal",
+    "description": "The ARIA label for the main navigation"
+  },
+  "theme.NotFound.p1": {
+    "message": "Não foi possível encontrar o que você está procurando.",
+    "description": "The first paragraph of the 404 page"
+  },
+  "theme.NotFound.p2": {
+    "message": "Por favor, entre em contato com o dono do site que ligou você à URL original e informe que o link está quebrado.",
+    "description": "The 2nd paragraph of the 404 page"
+  },
+  "theme.TOCCollapsible.toggleButtonLabel": {
+    "message": "Nesta página",
+    "description": "The label used by the button on the collapsible TOC component"
+  },
+  "theme.blog.post.readingTime.plurals": {
+    "message": "Um minuto para ler|{readingTime} min para ler",
+    "description": "Pluralized label for \"{readingTime} min read\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.post.readMore": {
+    "message": "Ler mais",
+    "description": "The label used in blog post item excerpts to link to full blog posts"
+  },
+  "theme.blog.post.readMoreLabel": {
+    "message": "Ler mais sobre {title}",
+    "description": "The ARIA label for the link to full blog posts from excerpts"
+  },
+  "theme.CodeBlock.copy": {
+    "message": "Copiar",
+    "description": "The copy button label on code blocks"
+  },
+  "theme.CodeBlock.copied": {
+    "message": "Copiado",
+    "description": "The copied button label on code blocks"
+  },
+  "theme.CodeBlock.copyButtonAriaLabel": {
+    "message": "Copiar código para a área de transferência",
+    "description": "The ARIA label for copy code blocks button"
+  },
+  "theme.CodeBlock.wordWrapToggle": {
+    "message": "Alternar quebra de linha",
+    "description": "The title attribute for toggle word wrapping button of code block lines"
+  },
+  "theme.docs.sidebar.collapseButtonTitle": {
+    "message": "Recolher painel lateral",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.sidebar.collapseButtonAriaLabel": {
+    "message": "Recolher painel lateral",
+    "description": "The title attribute for collapse button of doc sidebar"
+  },
+  "theme.docs.breadcrumbs.home": {
+    "message": "Página Inicial",
+    "description": "The ARIA label for the home page in the breadcrumbs"
+  },
+  "theme.docs.sidebar.navAriaLabel": {
+    "message": "Painel lateral de documentos",
+    "description": "The ARIA label for the sidebar navigation"
+  },
+  "theme.docs.sidebar.closeSidebarButtonAriaLabel": {
+    "message": "Fechar painel de navegação",
+    "description": "The ARIA label for close button of mobile sidebar"
+  },
+  "theme.navbar.mobileSidebarSecondaryMenu.backButtonLabel": {
+    "message": "← Voltar para o menu principal",
+    "description": "The label of the back button to return to main menu, inside the mobile navbar sidebar secondary menu (notably used to display the docs sidebar)"
+  },
+  "theme.docs.sidebar.toggleSidebarButtonAriaLabel": {
+    "message": "Alternar painel de navegação",
+    "description": "The ARIA label for hamburger menu button of mobile navigation"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.expandAriaLabel": {
+    "message": "Expandir a seleção",
+    "description": "The ARIA label of the button to expand the mobile dropdown navbar item"
+  },
+  "theme.navbar.mobileDropdown.collapseButton.collapseAriaLabel": {
+    "message": "Recolher a seleção",
+    "description": "The ARIA label of the button to collapse the mobile dropdown navbar item"
+  },
+  "theme.docs.sidebar.expandButtonTitle": {
+    "message": "Expandir painel lateral",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.docs.sidebar.expandButtonAriaLabel": {
+    "message": "Expandir painel lateral",
+    "description": "The ARIA label and title attribute for expand button of doc sidebar"
+  },
+  "theme.IdealImageMessage.loading": {
+    "message": "Carregando...",
+    "description": "When the full-scale image is loading"
+  },
+  "theme.IdealImageMessage.load": {
+    "message": "Clique para carregar{sizeMessage}",
+    "description": "To prompt users to load the full image. sizeMessage is a parenthesized size figure."
+  },
+  "theme.IdealImageMessage.offline": {
+    "message": "Seu browser está offline. Imagem não carregada",
+    "description": "When the user is viewing an offline document"
+  },
+  "theme.IdealImageMessage.404error": {
+    "message": "404. Imagem não encontrada",
+    "description": "When the image is not found"
+  },
+  "theme.IdealImageMessage.error": {
+    "message": "Erro. Clique para recarregar",
+    "description": "When the image fails to load for unknown error"
+  },
+  "theme.blog.post.plurals": {
+    "message": "Uma publicação|{count} publicações",
+    "description": "Pluralized label for \"{count} posts\". Use as much plural forms (separated by \"|\") as your language support (see https://www.unicode.org/cldr/cldr-aux/charts/34/supplemental/language_plural_rules.html)"
+  },
+  "theme.blog.tagTitle": {
+    "message": "{nPosts} com a etiqueta \"{tagName}\"",
+    "description": "The title of the page for a blog tag"
+  },
+  "theme.blog.author.pageTitle": {
+    "message": "{authorName} - {nPosts}",
+    "description": "The title of the page for a blog author"
+  },
+  "theme.blog.authorsList.pageTitle": {
+    "message": "Autores",
+    "description": "The title of the authors page"
+  },
+  "theme.blog.authorsList.viewAll": {
+    "message": "Ver todos os autores",
+    "description": "The label of the link targeting the blog authors page"
+  },
+  "theme.blog.author.noPosts": {
+    "message": "Este autor ainda não escreveu nenhuma publicação.",
+    "description": "The text for authors with 0 blog post"
+  },
+  "theme.contentVisibility.unlistedBanner.title": {
+    "message": "Página não listada",
+    "description": "The unlisted content banner title"
+  },
+  "theme.contentVisibility.unlistedBanner.message": {
+    "message": "Esta página não está listada. Mecanismos de busca não irão indexá-la, e somente usuários que possuam o link direto poderão acessá-la",
+    "description": "The unlisted content banner message"
+  },
+  "theme.contentVisibility.draftBanner.title": {
+    "message": "Página de rascunho",
+    "description": "The draft content banner title"
+  },
+  "theme.contentVisibility.draftBanner.message": {
+    "message": "Esta página é um rascunho. Ela estará visível apenas no desenvolvimento e será excluída da compilação de produção.",
+    "description": "The draft content banner message"
+  },
+  "theme.ErrorPageContent.tryAgain": {
+    "message": "Tentar novamente",
+    "description": "The label of the button to try again rendering when the React error boundary captures an error"
+  },
+  "theme.common.skipToMainContent": {
+    "message": "Pular para o conteúdo principal",
+    "description": "The skip to content label used for accessibility, allowing to rapidly navigate to main content with keyboard tab/enter navigation"
+  },
+  "theme.tags.tagsPageTitle": {
+    "message": "Etiquetas",
+    "description": "The title of the tag list page"
   }
 }

--- a/i18n/pt/docusaurus-theme-classic/footer.json
+++ b/i18n/pt/docusaurus-theme-classic/footer.json
@@ -1,0 +1,106 @@
+{
+  "links.title.Awana Digital": {
+    "message": "Awana Digital",
+    "description": "Footer section title: Awana Digital"
+  },
+  "links.Awana Digital.Website": {
+    "message": "Site",
+    "description": "Footer link label: Website"
+  },
+  "links.Awana Digital.Discord": {
+    "message": "Discord",
+    "description": "Footer link label: Discord"
+  },
+  "links.Awana Digital.Bluesky": {
+    "message": "Bluesky",
+    "description": "Footer link label: Bluesky"
+  },
+  "links.Awana Digital.Blog": {
+    "message": "Blog",
+    "description": "Footer link label: Blog"
+  },
+  "links.title.CoMapeo": {
+    "message": "CoMapeo",
+    "description": "Footer section title: CoMapeo"
+  },
+  "links.CoMapeo.Website": {
+    "message": "Site",
+    "description": "Footer link label: Website"
+  },
+  "links.CoMapeo.CoMapeo Mobile GitHub": {
+    "message": "GitHub do CoMapeo Mobile",
+    "description": "Footer link label: CoMapeo Mobile GitHub"
+  },
+  "links.CoMapeo.CoMapeo Desktop GitHub": {
+    "message": "GitHub do CoMapeo Desktop",
+    "description": "Footer link label: CoMapeo Desktop GitHub"
+  },
+  "links.title.More": {
+    "message": "Mais",
+    "description": "Footer section title: More"
+  },
+  "links.More.PlayStore": {
+    "message": "PlayStore",
+    "description": "Footer link label: PlayStore"
+  },
+  "links.More.GitHub": {
+    "message": "GitHub",
+    "description": "Footer link label: GitHub"
+  },
+  "links.More.Earth Defenders Toolkit": {
+    "message": "Earth Defenders Toolkit",
+    "description": "Footer link label: Earth Defenders Toolkit"
+  },
+  "copyright": {
+    "message": "Feito com ❤️ por Awana Digital - 2026",
+    "description": "The footer copyright"
+  },
+  "link.title.Awana Digital": {
+    "message": "Awana Digital",
+    "description": "The title of the footer links column with title=Awana Digital in the footer"
+  },
+  "link.title.CoMapeo": {
+    "message": "CoMapeo",
+    "description": "The title of the footer links column with title=CoMapeo in the footer"
+  },
+  "link.title.More": {
+    "message": "Mais",
+    "description": "The title of the footer links column with title=More in the footer"
+  },
+  "link.item.label.Website": {
+    "message": "Site",
+    "description": "The label of footer link with label=Website linking to https://comapeo.app"
+  },
+  "link.item.label.Discord": {
+    "message": "Discord",
+    "description": "The label of footer link with label=Discord linking to https://discord.gg/NtZgtAjj"
+  },
+  "link.item.label.Bluesky": {
+    "message": "Bluesky",
+    "description": "The label of footer link with label=Bluesky linking to https://bsky.app/profile/awana.digital"
+  },
+  "link.item.label.Blog": {
+    "message": "Blog",
+    "description": "The label of footer link with label=Blog linking to https://awana.digital/blog"
+  },
+  "link.item.label.CoMapeo Mobile GitHub": {
+    "message": "GitHub do CoMapeo Mobile",
+    "description": "The label of footer link with label=CoMapeo Mobile GitHub linking to https://github.com/digidem/comapeo-docs"
+  },
+  "link.item.label.CoMapeo Desktop GitHub": {
+    "message": "GitHub do CoMapeo Desktop",
+    "description": "The label of footer link with label=CoMapeo Desktop GitHub linking to https://github.com/digidem/comapeo-docs"
+  },
+  "link.item.label.PlayStore": {
+    "message": "PlayStore",
+    "description": "The label of footer link with label=PlayStore linking to https://play.google.com/store/apps/details?id=com.comapeo"
+  },
+  "link.item.label.GitHub": {
+    "message": "GitHub",
+    "description": "The label of footer link with label=GitHub linking to https://github.com/digidem/comapeo-docs"
+  },
+  "link.item.label.Earth Defenders Toolkit": {
+    "message": "Earth Defenders Toolkit",
+    "description": "The label of footer link with label=Earth Defenders Toolkit linking to https://www.earthdefenderstoolkit.com/"
+  }
+}

--- a/i18n/pt/docusaurus-theme-classic/navbar.json
+++ b/i18n/pt/docusaurus-theme-classic/navbar.json
@@ -1,0 +1,14 @@
+{
+  "item.label.Documentation": {
+    "message": "Documentação",
+    "description": "Navbar item with label Documentation"
+  },
+  "item.label.GitHub": {
+    "message": "GitHub",
+    "description": "Navbar item with label GitHub"
+  },
+  "logo.alt": {
+    "message": "CoMapeo",
+    "description": "The alt text of navbar logo"
+  }
+}

--- a/scripts/locale-parity.test.ts
+++ b/scripts/locale-parity.test.ts
@@ -1160,4 +1160,101 @@ Título
       });
     });
   });
+
+  describe("Real project structural parity", () => {
+    it("has no empty translations in existing localized files", async () => {
+      const projectRoot = process.cwd();
+      let issues: ParityIssue[];
+
+      try {
+        issues = await collectParityIssues(projectRoot);
+      } catch (error) {
+        if (isMissingDirectoryError(error)) {
+          return;
+        }
+        throw error;
+      }
+
+      const emptyIssues = issues.filter(
+        (issue) => issue.type === "empty-translation"
+      );
+
+      if (emptyIssues.length > 0) {
+        const lines = emptyIssues.map(
+          (i) => `  ${i.key} (${i.locale}): ${i.type}`
+        );
+        console.warn(`Real project empty translations:\n${lines.join("\n")}`);
+      }
+
+      expect(
+        emptyIssues.length,
+        `Found ${emptyIssues.length} empty translations in real locale files`
+      ).toBe(0);
+    });
+
+    it("has no frontmatter mismatches when validation is enabled", async () => {
+      if (!shouldValidateFrontmatter()) {
+        return;
+      }
+
+      const projectRoot = process.cwd();
+      const issues = await collectParityIssues(projectRoot);
+
+      const frontmatterIssues = issues.filter(
+        (issue) => issue.type === "frontmatter-mismatch"
+      );
+
+      expect(
+        frontmatterIssues,
+        `Found ${frontmatterIssues.length} frontmatter mismatches`
+      ).toEqual([]);
+    });
+
+    it("has non-empty labels in real locale _category_.json files", async () => {
+      const locales = ["pt", "es"] as const;
+      for (const locale of locales) {
+        const localeRoot = getLocaleRoot(process.cwd(), locale);
+        let entries;
+        try {
+          entries = await fs.readdir(localeRoot, { withFileTypes: true });
+        } catch {
+          continue;
+        }
+
+        const findCategoryFiles = async (dir: string): Promise<string[]> => {
+          const results: string[] = [];
+          let dirEntries;
+          try {
+            dirEntries = await fs.readdir(dir, { withFileTypes: true });
+          } catch {
+            return results;
+          }
+          for (const entry of dirEntries) {
+            const fullPath = path.join(dir, entry.name);
+            if (entry.isDirectory()) {
+              results.push(...(await findCategoryFiles(fullPath)));
+            } else if (entry.name === "_category_.json") {
+              results.push(fullPath);
+            }
+          }
+          return results;
+        };
+
+        const categoryFiles = await findCategoryFiles(localeRoot);
+
+        for (const filePath of categoryFiles) {
+          const content = await fs.readFile(filePath, "utf8");
+          const category = JSON.parse(content);
+          expect(
+            typeof category.label,
+            `${locale} ${filePath}: label missing`
+          ).toBe("string");
+          expect(
+            category.label.trim().length,
+            `${locale} ${filePath}: label is empty`
+          ).toBeGreaterThan(0);
+        }
+      }
+    });
+  });
 });

--- a/scripts/notion-translate/translateCodeJson.test.ts
+++ b/scripts/notion-translate/translateCodeJson.test.ts
@@ -114,4 +114,88 @@ describe("notion-translate translateCodeJson", () => {
     expect(request?.response_format?.type).toBe("json_object");
     expect(request?.max_tokens).toBe(DEFAULT_OPENAI_MAX_TOKENS);
   });
+
+  describe("extractTranslatableText", () => {
+    it("extracts navbar item labels and logo.alt", async () => {
+      const { extractTranslatableText } = await importTranslateCodeJson();
+
+      const result = extractTranslatableText(
+        {
+          logo: { alt: "CoMapeo" },
+          items: [
+            { label: "Documentation", type: "docSidebar" },
+            { label: "GitHub", href: "https://github.com/example" },
+          ],
+        },
+        "navbar"
+      );
+
+      expect(result).toEqual({
+        "item.label.Documentation": {
+          message: "Documentation",
+          description: "Navbar item with label Documentation",
+        },
+        "item.label.GitHub": {
+          message: "GitHub",
+          description: "Navbar item with label GitHub",
+        },
+        "logo.alt": {
+          message: "CoMapeo",
+          description: "The alt text of navbar logo",
+        },
+      });
+    });
+
+    it("omits logo.alt when navbar config has no logo", async () => {
+      const { extractTranslatableText } = await importTranslateCodeJson();
+
+      const result = extractTranslatableText(
+        { items: [{ label: "Documentation" }] },
+        "navbar"
+      );
+
+      expect(result).not.toHaveProperty("logo.alt");
+      expect(result["item.label.Documentation"]).toBeDefined();
+    });
+
+    it("extracts footer section titles and item labels in both the legacy and Docusaurus runtime key formats", async () => {
+      const { extractTranslatableText } = await importTranslateCodeJson();
+
+      const result = extractTranslatableText(
+        {
+          links: [
+            {
+              title: "CoMapeo",
+              items: [{ label: "Website", href: "https://comapeo.app" }],
+            },
+          ],
+          copyright: "Made with love",
+        },
+        "footer"
+      );
+
+      expect(result["links.title.CoMapeo"]).toEqual({
+        message: "CoMapeo",
+        description: "Footer section title: CoMapeo",
+      });
+      expect(result["link.title.CoMapeo"]).toEqual({
+        message: "CoMapeo",
+        description:
+          "The title of the footer links column with title=CoMapeo in the footer",
+      });
+      expect(result["links.CoMapeo.Website"]).toEqual({
+        message: "Website",
+        description: "Footer link label: Website",
+      });
+      expect(result["link.item.label.Website"]).toEqual({
+        message: "Website",
+        description:
+          "The label of footer link with label=Website linking to https://comapeo.app",
+      });
+      expect(result.copyright).toEqual({
+        message: "Made with love",
+        description: "Footer copyright text",
+      });
+    });
+  });
 });

--- a/scripts/notion-translate/translateCodeJson.ts
+++ b/scripts/notion-translate/translateCodeJson.ts
@@ -174,7 +174,7 @@ export function extractTranslatableText(
       nav.items.forEach((item: NavbarItem) => {
         if (item.label) {
           const key = `item.label.${item.label}`;
-          // eslint-disable-next-line security/detect-object-injection -- translation keys are generated from controlled config labels
+
           result[key] = {
             message: item.label,
             description: `Navbar item with label ${item.label}`,
@@ -190,10 +190,19 @@ export function extractTranslatableText(
       footer.links.forEach((section: FooterSection) => {
         if (section.title) {
           const titleKey = `links.title.${section.title}`;
-          // eslint-disable-next-line security/detect-object-injection -- translation keys are generated from controlled config labels
+
           result[titleKey] = {
             message: section.title,
             description: `Footer section title: ${section.title}`,
+          };
+
+          // Docusaurus's own footer i18n key (see @docusaurus/theme-classic
+          // translations.js): required or translations are dropped at runtime.
+          const docusaurusTitleKey = `link.title.${section.title}`;
+
+          result[docusaurusTitleKey] = {
+            message: section.title,
+            description: `The title of the footer links column with title=${section.title} in the footer`,
           };
         }
 
@@ -201,10 +210,19 @@ export function extractTranslatableText(
           section.items.forEach((item: FooterLink) => {
             if (item.label) {
               const labelKey = `links.${section.title}.${item.label}`;
-              // eslint-disable-next-line security/detect-object-injection -- translation keys are generated from controlled config labels
+
               result[labelKey] = {
                 message: item.label,
                 description: `Footer link label: ${item.label}`,
+              };
+
+              // Docusaurus's own footer i18n key (see @docusaurus/theme-classic
+              // translations.js): required or translations are dropped at runtime.
+              const docusaurusLabelKey = `link.item.label.${item.label}`;
+
+              result[docusaurusLabelKey] = {
+                message: item.label,
+                description: `The label of footer link with label=${item.label} linking to ${item.href ?? ""}`,
               };
             }
           });
@@ -312,7 +330,6 @@ export function getLanguageName(langCode: string): string {
     en: "English",
   };
 
-  // eslint-disable-next-line security/detect-object-injection -- dictionary lookup by locale code is expected behavior
   return languageMap[langCode] || langCode;
 }
 

--- a/scripts/notion-translate/translateCodeJson.ts
+++ b/scripts/notion-translate/translateCodeJson.ts
@@ -153,8 +153,13 @@ interface FooterSection {
   items?: FooterLink[];
 }
 
+interface NavbarLogo {
+  alt?: string;
+}
+
 interface NavbarConfig {
   items?: NavbarItem[];
+  logo?: NavbarLogo;
 }
 
 interface FooterConfig {
@@ -181,6 +186,15 @@ export function extractTranslatableText(
           };
         }
       });
+    }
+
+    // Docusaurus's own navbar i18n key (see @docusaurus/theme-classic
+    // translations.js): required or the logo alt text is dropped at runtime.
+    if (nav.logo?.alt) {
+      result["logo.alt"] = {
+        message: nav.logo.alt,
+        description: "The alt text of navbar logo",
+      };
     }
   }
 

--- a/scripts/verify-locale-output.test.ts
+++ b/scripts/verify-locale-output.test.ts
@@ -9,134 +9,236 @@ interface TranslationEntry {
 
 type TranslationCodeJson = Record<string, TranslationEntry>;
 
+const PLACEHOLDER_PATTERNS_ES = [
+  /^Nueva P[aá]gina( A)?$/u,
+  /^Nuevo t[ií]tulo de secci[oó]n$/u,
+  /^Nueva Palanca$/u,
+];
+
+const PLACEHOLDER_PATTERNS_PT = [
+  /^Nova P[aá]gina( A)?$/u,
+  /^Novo t[ií]tulo da se[cç][aã]o$/u,
+  /^Novo Alternar$/u,
+];
+
 const parseTranslationCodeJson = (content: string): TranslationCodeJson =>
   JSON.parse(content) as TranslationCodeJson;
 
-/**
- * Verification tests for locale output correctness
- *
- * These tests verify that:
- * 1. Locale files contain translated content (not English)
- * 2. No unintended English writes occurred in non-English locales
- * 3. Locale files have the expected structure
- * 4. Translation keys match between source and target locales
- */
+const readJsonFile = async (filePath: string): Promise<unknown> => {
+  const content = await fs.readFile(filePath, "utf8");
+  return JSON.parse(content);
+};
+
+const readTranslationCodeJson = async (
+  filePath: string
+): Promise<TranslationCodeJson> => {
+  const content = await fs.readFile(filePath, "utf8");
+  return parseTranslationCodeJson(content);
+};
+
+const assertFileExists = async (filePath: string): Promise<void> => {
+  try {
+    await fs.access(filePath);
+  } catch {
+    throw new Error(
+      `Required file not found: ${path.relative(process.cwd(), filePath)}`
+    );
+  }
+};
+
+const assertTranslationFileHasExpectedKeys = (
+  translations: TranslationCodeJson,
+  expectedKeys: string[],
+  fileLabel: string
+): void => {
+  for (const key of expectedKeys) {
+    if (!(key in translations)) {
+      throw new Error(`${fileLabel}: missing required key "${key}"`);
+    }
+    // eslint-disable-next-line security/detect-object-injection -- key comes from the hardcoded expectedKeys param, never external input
+    const entry = translations[key];
+    if (
+      !entry ||
+      typeof entry.message !== "string" ||
+      entry.message.trim().length === 0
+    ) {
+      throw new Error(
+        `${fileLabel}: key "${key}" has empty or missing message`
+      );
+    }
+  }
+};
+
+const assertNoPlaceholderMessages = (
+  translations: TranslationCodeJson,
+  patterns: RegExp[],
+  fileLabel: string
+): void => {
+  const violations: string[] = [];
+  for (const [key, entry] of Object.entries(translations)) {
+    if (!entry.message) continue;
+    for (const pattern of patterns) {
+      if (pattern.test(entry.message.trim())) {
+        violations.push(`  "${key}": "${entry.message}"`);
+        break;
+      }
+    }
+  }
+  if (violations.length > 0) {
+    throw new Error(
+      `${fileLabel}: found ${violations.length} placeholder message(s):\n${violations.join("\n")}`
+    );
+  }
+};
+
+const assertNoUntranslatedMessages = (
+  translations: TranslationCodeJson,
+  fileLabel: string
+): void => {
+  const violations: string[] = [];
+  for (const [key, entry] of Object.entries(translations)) {
+    if (!entry.message) continue;
+    if (entry.message === key) {
+      violations.push(`  "${key}": message identical to key (untranslated)`);
+    }
+  }
+  if (violations.length > 0) {
+    throw new Error(
+      `${fileLabel}: found ${violations.length} untranslated message(s):\n${violations.join("\n")}`
+    );
+  }
+};
+
+const NAVBAR_EXPECTED_KEYS = [
+  "item.label.Documentation",
+  "item.label.GitHub",
+  "logo.alt",
+];
+
+const FOOTER_EXPECTED_KEYS = [
+  "links.title.Awana Digital",
+  "links.Awana Digital.Website",
+  "links.Awana Digital.Discord",
+  "links.Awana Digital.Bluesky",
+  "links.Awana Digital.Blog",
+  "links.title.CoMapeo",
+  "links.CoMapeo.Website",
+  "links.CoMapeo.CoMapeo Mobile GitHub",
+  "links.CoMapeo.CoMapeo Desktop GitHub",
+  "links.title.More",
+  "links.More.PlayStore",
+  "links.More.GitHub",
+  "links.More.Earth Defenders Toolkit",
+  "copyright",
+  "link.title.More",
+  "link.item.label.Website",
+  "link.item.label.CoMapeo Mobile GitHub",
+  "link.item.label.CoMapeo Desktop GitHub",
+];
+
+const GENERIC_TRANSLATABLE_LABELS = [
+  {
+    locale: "es",
+    key: "item.label.Documentation",
+    english: "Documentation",
+    hint: "Documentación",
+  },
+  {
+    locale: "pt",
+    key: "item.label.Documentation",
+    english: "Documentation",
+    hint: "Documentação",
+  },
+  {
+    locale: "es",
+    key: "links.Awana Digital.Website",
+    english: "Website",
+    hint: "Sitio web",
+  },
+  {
+    locale: "pt",
+    key: "links.Awana Digital.Website",
+    english: "Website",
+    hint: "Site",
+  },
+  {
+    locale: "es",
+    key: "links.CoMapeo.Website",
+    english: "Website",
+    hint: "Sitio web",
+  },
+  {
+    locale: "pt",
+    key: "links.CoMapeo.Website",
+    english: "Website",
+    hint: "Site",
+  },
+  { locale: "es", key: "links.title.More", english: "More", hint: "Más" },
+  { locale: "pt", key: "links.title.More", english: "More", hint: "Mais" },
+  { locale: "es", key: "link.title.More", english: "More", hint: "Más" },
+  { locale: "pt", key: "link.title.More", english: "More", hint: "Mais" },
+  {
+    locale: "es",
+    key: "link.item.label.Website",
+    english: "Website",
+    hint: "Sitio web",
+  },
+  {
+    locale: "pt",
+    key: "link.item.label.Website",
+    english: "Website",
+    hint: "Site",
+  },
+  {
+    locale: "es",
+    key: "link.item.label.CoMapeo Mobile GitHub",
+    english: "CoMapeo Mobile GitHub",
+    hint: "GitHub de CoMapeo Mobile",
+  },
+  {
+    locale: "pt",
+    key: "link.item.label.CoMapeo Mobile GitHub",
+    english: "CoMapeo Mobile GitHub",
+    hint: "GitHub do CoMapeo Mobile",
+  },
+  {
+    locale: "es",
+    key: "link.item.label.CoMapeo Desktop GitHub",
+    english: "CoMapeo Desktop GitHub",
+    hint: "GitHub de CoMapeo Desktop",
+  },
+  {
+    locale: "pt",
+    key: "link.item.label.CoMapeo Desktop GitHub",
+    english: "CoMapeo Desktop GitHub",
+    hint: "GitHub do CoMapeo Desktop",
+  },
+];
+
 describe("Locale Output Verification", () => {
   const i18nDir = path.join(process.cwd(), "i18n");
 
   describe("Spanish locale (es)", () => {
-    it("has code.json with Spanish translations", async () => {
+    it("has code.json with no placeholder or untranslated messages", async () => {
       const codeJsonPath = path.join(i18nDir, "es", "code.json");
+      const codeJson = await readTranslationCodeJson(codeJsonPath);
 
-      // Read and parse the file
-      const content = await fs.readFile(codeJsonPath, "utf8");
-      const codeJson = parseTranslationCodeJson(content);
-
-      // Verify it has translations
       expect(Object.keys(codeJson).length).toBeGreaterThan(0);
-
-      // Sample a few keys to verify they're in Spanish (not English)
-      const sampleKeys = Object.keys(codeJson).slice(0, 5);
-
-      for (const key of sampleKeys) {
-        // eslint-disable-next-line security/detect-object-injection -- test code with controlled JSON data
-        const entry = codeJson[key];
-        if (entry.message) {
-          // Check that it's not English by looking for common English words
-          const message = entry.message.toLowerCase();
-
-          // Skip "Nova Página" and "Nuevo título" which are placeholder translations
-          if (
-            message.includes("nova página") ||
-            message.includes("nuevo título")
-          ) {
-            continue;
-          }
-
-          // Verify it's not English by checking for Spanish indicators
-          const hasSpanishIndicators =
-            message.includes(" en ") ||
-            message.includes(" de ") ||
-            message.includes(" para ") ||
-            message.includes(" el ") ||
-            message.includes(" la ") ||
-            message.includes("ón") ||
-            message.includes("ción") ||
-            message.includes(" esta ") ||
-            message.includes("nueva") ||
-            message.includes("página") ||
-            message.includes("introducción");
-
-          // If it doesn't have Spanish indicators, it might be a proper noun or short text
-          // We'll just verify it's a valid string for now
-          expect(typeof entry.message).toBe("string");
-          expect(entry.message.length).toBeGreaterThan(0);
-        }
-      }
-    });
-
-    it("does not contain unintended English content in code.json", async () => {
-      const codeJsonPath = path.join(i18nDir, "es", "code.json");
-      const content = await fs.readFile(codeJsonPath, "utf8");
-      const codeJson = parseTranslationCodeJson(content);
-
-      // Check that common English words are not present in messages
-      // (except for proper nouns or technical terms)
-      const englishOnlyPatterns = [
-        /\bthe\b/i,
-        /\bis\b/i,
-        /\band\b/i,
-        /\bfor\b/i,
-        /\bwith\b/i,
-        /\bgetting started\b/i,
-        /\bdevice setup\b/i,
-      ];
-
-      let hasUnintendedEnglish = false;
-      const unintendedEnglishEntries: string[] = [];
-
-      for (const [key, entry] of Object.entries(codeJson)) {
-        if (entry.message) {
-          const message = entry.message.toLowerCase();
-
-          // Skip placeholder translations
-          if (
-            message.includes("nova página") ||
-            message.includes("nuevo título")
-          ) {
-            continue;
-          }
-
-          // Check for multiple English-only patterns (suggesting untranslated content)
-          const matchCount = englishOnlyPatterns.filter((pattern) =>
-            pattern.test(message)
-          ).length;
-
-          if (matchCount >= 3) {
-            // If 3+ English patterns match, likely untranslated
-            hasUnintendedEnglish = true;
-            unintendedEnglishEntries.push(`${key}: ${entry.message}`);
-          }
-        }
-      }
-
-      expect(
-        hasUnintendedEnglish,
-        `Found potential untranslated English content in es/code.json:\n${unintendedEnglishEntries.join("\n")}`
-      ).toBe(false);
+      assertNoPlaceholderMessages(
+        codeJson,
+        PLACEHOLDER_PATTERNS_ES,
+        "es/code.json"
+      );
+      assertNoUntranslatedMessages(codeJson, "es/code.json");
     });
 
     it("has valid structure with message and optional description", async () => {
       const codeJsonPath = path.join(i18nDir, "es", "code.json");
-      const content = await fs.readFile(codeJsonPath, "utf8");
-      const codeJson = parseTranslationCodeJson(content);
+      const codeJson = await readTranslationCodeJson(codeJsonPath);
 
       for (const [key, entry] of Object.entries(codeJson)) {
-        // Every entry must have a message
         expect(entry).toHaveProperty("message");
         expect(typeof entry.message).toBe("string");
-
-        // Description is optional but must be string if present
         if (entry.description) {
           expect(typeof entry.description).toBe("string");
         }
@@ -145,93 +247,26 @@ describe("Locale Output Verification", () => {
   });
 
   describe("Portuguese locale (pt)", () => {
-    it("has code.json with Portuguese translations", async () => {
+    it("has code.json with no placeholder or untranslated messages", async () => {
       const codeJsonPath = path.join(i18nDir, "pt", "code.json");
-
-      const content = await fs.readFile(codeJsonPath, "utf8");
-      const codeJson = parseTranslationCodeJson(content);
+      const codeJson = await readTranslationCodeJson(codeJsonPath);
 
       expect(Object.keys(codeJson).length).toBeGreaterThan(0);
-
-      const sampleKeys = Object.keys(codeJson).slice(0, 5);
-
-      for (const key of sampleKeys) {
-        // eslint-disable-next-line security/detect-object-injection -- test code with controlled JSON data
-        const entry = codeJson[key];
-        if (entry.message) {
-          const message = entry.message.toLowerCase();
-
-          // Skip placeholder translations
-          if (
-            message.includes("nova página") ||
-            message.includes("novo título")
-          ) {
-            continue;
-          }
-
-          // Verify it's a valid string
-          expect(typeof entry.message).toBe("string");
-          expect(entry.message.length).toBeGreaterThan(0);
-        }
-      }
-    });
-
-    it("does not contain unintended English content in code.json", async () => {
-      const codeJsonPath = path.join(i18nDir, "pt", "code.json");
-      const content = await fs.readFile(codeJsonPath, "utf8");
-      const codeJson = parseTranslationCodeJson(content);
-
-      const englishOnlyPatterns = [
-        /\bthe\b/i,
-        /\bis\b/i,
-        /\band\b/i,
-        /\bfor\b/i,
-        /\bwith\b/i,
-        /\bgetting started\b/i,
-        /\bdevice setup\b/i,
-      ];
-
-      let hasUnintendedEnglish = false;
-      const unintendedEnglishEntries: string[] = [];
-
-      for (const [key, entry] of Object.entries(codeJson)) {
-        if (entry.message) {
-          const message = entry.message.toLowerCase();
-
-          // Skip placeholder translations
-          if (
-            message.includes("nova página") ||
-            message.includes("novo título")
-          ) {
-            continue;
-          }
-
-          const matchCount = englishOnlyPatterns.filter((pattern) =>
-            pattern.test(message)
-          ).length;
-
-          if (matchCount >= 3) {
-            hasUnintendedEnglish = true;
-            unintendedEnglishEntries.push(`${key}: ${entry.message}`);
-          }
-        }
-      }
-
-      expect(
-        hasUnintendedEnglish,
-        `Found potential untranslated English content in pt/code.json:\n${unintendedEnglishEntries.join("\n")}`
-      ).toBe(false);
+      assertNoPlaceholderMessages(
+        codeJson,
+        PLACEHOLDER_PATTERNS_PT,
+        "pt/code.json"
+      );
+      assertNoUntranslatedMessages(codeJson, "pt/code.json");
     });
 
     it("has valid structure with message and optional description", async () => {
       const codeJsonPath = path.join(i18nDir, "pt", "code.json");
-      const content = await fs.readFile(codeJsonPath, "utf8");
-      const codeJson = parseTranslationCodeJson(content);
+      const codeJson = await readTranslationCodeJson(codeJsonPath);
 
       for (const [key, entry] of Object.entries(codeJson)) {
         expect(entry).toHaveProperty("message");
         expect(typeof entry.message).toBe("string");
-
         if (entry.description) {
           expect(typeof entry.description).toBe("string");
         }
@@ -244,34 +279,18 @@ describe("Locale Output Verification", () => {
       const esCodeJsonPath = path.join(i18nDir, "es", "code.json");
       const ptCodeJsonPath = path.join(i18nDir, "pt", "code.json");
 
-      const esContent = await fs.readFile(esCodeJsonPath, "utf8");
-      const ptContent = await fs.readFile(ptCodeJsonPath, "utf8");
-
-      const esCodeJson = parseTranslationCodeJson(esContent);
-      const ptCodeJson = parseTranslationCodeJson(ptContent);
+      const esCodeJson = await readTranslationCodeJson(esCodeJsonPath);
+      const ptCodeJson = await readTranslationCodeJson(ptCodeJsonPath);
 
       const esKeys = Object.keys(esCodeJson).sort();
       const ptKeys = Object.keys(ptCodeJson).sort();
 
-      // Should have the same number of keys
       expect(esKeys.length).toBe(ptKeys.length);
 
-      // Check for keys that differ (may indicate data quality issues)
       const diff = esKeys
         .filter((k) => !ptKeys.includes(k))
         .concat(ptKeys.filter((k) => !esKeys.includes(k)));
 
-      if (diff.length > 0) {
-        console.warn(
-          "Warning: Translation keys differ between es and pt locales:",
-          diff
-        );
-        console.warn(
-          "This may indicate a data quality issue - translation keys should be based on English source"
-        );
-      }
-
-      // Allow up to 10% difference in keys, with minimum of 3 to handle small datasets
       const maxAllowedDiff = Math.max(3, Math.ceil(esKeys.length * 0.1));
       expect(
         diff.length,
@@ -288,55 +307,41 @@ describe("Locale Output Verification", () => {
           "docusaurus-plugin-content-docs",
           "current"
         );
+
+        const findCategoryFiles = async (dir: string): Promise<string[]> => {
+          const results: string[] = [];
+          let entries;
+          try {
+            entries = await fs.readdir(dir, { withFileTypes: true });
+          } catch {
+            return results;
+          }
+          for (const entry of entries) {
+            const fullPath = path.join(dir, entry.name);
+            if (entry.isDirectory()) {
+              results.push(...(await findCategoryFiles(fullPath)));
+            } else if (entry.name === "_category_.json") {
+              results.push(fullPath);
+            }
+          }
+          return results;
+        };
+
         let categoryFiles: string[];
         try {
-          // Recursively find all _category_.json files under the locale docs dir
-          const findCategoryFiles = async (dir: string): Promise<string[]> => {
-            const results: string[] = [];
-            let entries;
-            try {
-              entries = await fs.readdir(dir, { withFileTypes: true });
-            } catch {
-              return results;
-            }
-            for (const entry of entries) {
-              const fullPath = path.join(dir, entry.name);
-              if (entry.isDirectory()) {
-                results.push(...(await findCategoryFiles(fullPath)));
-              } else if (entry.name === "_category_.json") {
-                results.push(fullPath);
-              }
-            }
-            return results;
-          };
           categoryFiles = await findCategoryFiles(localeDocsDir);
-        } catch (error) {
-          if (
-            error instanceof Error &&
-            "code" in error &&
-            (error as NodeJS.ErrnoException).code === "ENOENT"
-          ) {
-            console.log(
-              `${locale} locale docs directory not found - content branch may not have toggle pages`
-            );
-            continue;
-          }
-          throw error;
-        }
-
-        if (categoryFiles.length === 0) {
-          console.log(
-            `No _category_.json files found for locale ${locale} - may not have toggle pages`
-          );
+        } catch {
           continue;
         }
+
+        if (categoryFiles.length === 0) continue;
 
         for (const filePath of categoryFiles) {
           const content = await fs.readFile(filePath, "utf8");
           const category = JSON.parse(content);
           expect(
             category.label,
-            `_category_.json at ${filePath} has empty label`
+            `_category_.json at ${path.relative(process.cwd(), filePath)} has empty label`
           ).toBeTruthy();
           expect(typeof category.label).toBe("string");
           expect(category.label.trim().length).toBeGreaterThan(0);
@@ -344,160 +349,88 @@ describe("Locale Output Verification", () => {
       }
     });
 
-    it("does not have English locale directory (en/)", async () => {
+    it("does not have English locale directory (en/) with code.json", async () => {
       const enDir = path.join(i18nDir, "en");
-
-      // English source files should NOT be in i18n/en/
-      // They should be in the root or handled separately
       try {
         await fs.access(enDir);
-        // If we get here, the directory exists - this might be a problem
-        // Check if it has code.json
         const enCodeJsonPath = path.join(enDir, "code.json");
         try {
           await fs.access(enCodeJsonPath);
-          // English code.json exists in i18n/en/ - this could cause issues
-          // Log a warning but don't fail (it might be intentional for source)
-          console.warn(
-            "Warning: i18n/en/code.json exists. This should only contain source English strings."
-          );
+          console.warn("Warning: i18n/en/code.json exists.");
         } catch {
-          // Directory exists but no code.json - that's fine
+          // no code.json - fine
         }
       } catch {
-        // Directory doesn't exist - that's expected
+        // directory doesn't exist - expected
       }
     });
   });
 
   describe("Theme translations", () => {
-    it("has navbar.json for Spanish", async () => {
-      const navbarPath = path.join(
+    const verifyThemeFile = async (
+      locale: string,
+      fileName: string,
+      expectedKeys: string[]
+    ): Promise<void> => {
+      const filePath = path.join(
         i18nDir,
-        "es",
+        locale,
         "docusaurus-theme-classic",
-        "navbar.json"
+        fileName
       );
 
-      try {
-        const content = await fs.readFile(navbarPath, "utf8");
-        const navbar = JSON.parse(content);
+      await assertFileExists(filePath);
 
-        expect(Object.keys(navbar).length).toBeGreaterThan(0);
+      const data = (await readJsonFile(filePath)) as TranslationCodeJson;
+      assertTranslationFileHasExpectedKeys(
+        data,
+        expectedKeys,
+        `${locale}/docusaurus-theme-classic/${fileName}`
+      );
+    };
 
-        // Verify entries have messages
-        for (const [key, entry] of Object.entries(navbar)) {
-          expect(entry).toHaveProperty("message");
-        }
-      } catch (error) {
-        // Only catch ENOENT (file not found) - let other errors propagate
-        if (
-          error instanceof Error &&
-          "code" in error &&
-          error.code === "ENOENT"
-        ) {
-          console.log(
-            "Spanish navbar.json not found - may need to run translation"
-          );
-          return; // Exit gracefully for missing file only
-        }
-        throw error; // Re-throw all other errors (including assertion failures)
-      }
+    it("has navbar.json for Spanish with expected keys", async () => {
+      await verifyThemeFile("es", "navbar.json", NAVBAR_EXPECTED_KEYS);
     });
 
-    it("has footer.json for Spanish", async () => {
-      const footerPath = path.join(
-        i18nDir,
-        "es",
-        "docusaurus-theme-classic",
-        "footer.json"
-      );
-
-      try {
-        const content = await fs.readFile(footerPath, "utf8");
-        const footer = JSON.parse(content);
-
-        expect(Object.keys(footer).length).toBeGreaterThan(0);
-
-        for (const [key, entry] of Object.entries(footer)) {
-          expect(entry).toHaveProperty("message");
-        }
-      } catch (error) {
-        if (
-          error instanceof Error &&
-          "code" in error &&
-          error.code === "ENOENT"
-        ) {
-          console.log(
-            "Spanish footer.json not found - may need to run translation"
-          );
-          return;
-        }
-        throw error;
-      }
+    it("has footer.json for Spanish with expected keys", async () => {
+      await verifyThemeFile("es", "footer.json", FOOTER_EXPECTED_KEYS);
     });
 
-    it("has navbar.json for Portuguese", async () => {
-      const navbarPath = path.join(
-        i18nDir,
-        "pt",
-        "docusaurus-theme-classic",
-        "navbar.json"
-      );
-
-      try {
-        const content = await fs.readFile(navbarPath, "utf8");
-        const navbar = JSON.parse(content);
-
-        expect(Object.keys(navbar).length).toBeGreaterThan(0);
-
-        for (const [key, entry] of Object.entries(navbar)) {
-          expect(entry).toHaveProperty("message");
-        }
-      } catch (error) {
-        if (
-          error instanceof Error &&
-          "code" in error &&
-          error.code === "ENOENT"
-        ) {
-          console.log(
-            "Portuguese navbar.json not found - may need to run translation"
-          );
-          return;
-        }
-        throw error;
-      }
+    it("has navbar.json for Portuguese with expected keys", async () => {
+      await verifyThemeFile("pt", "navbar.json", NAVBAR_EXPECTED_KEYS);
     });
 
-    it("has footer.json for Portuguese", async () => {
-      const footerPath = path.join(
-        i18nDir,
-        "pt",
-        "docusaurus-theme-classic",
-        "footer.json"
-      );
+    it("has footer.json for Portuguese with expected keys", async () => {
+      await verifyThemeFile("pt", "footer.json", FOOTER_EXPECTED_KEYS);
+    });
 
-      try {
-        const content = await fs.readFile(footerPath, "utf8");
-        const footer = JSON.parse(content);
-
-        expect(Object.keys(footer).length).toBeGreaterThan(0);
-
-        for (const [key, entry] of Object.entries(footer)) {
-          expect(entry).toHaveProperty("message");
-        }
-      } catch (error) {
-        if (
-          error instanceof Error &&
-          "code" in error &&
-          error.code === "ENOENT"
-        ) {
-          console.log(
-            "Portuguese footer.json not found - may need to run translation"
-          );
-          return;
-        }
-        throw error;
+    it("localizes generic translatable UI labels", async () => {
+      for (const {
+        locale,
+        key,
+        english,
+        hint,
+      } of GENERIC_TRANSLATABLE_LABELS) {
+        const filePath = path.join(
+          i18nDir,
+          locale,
+          "docusaurus-theme-classic",
+          key.startsWith("item.label.") ? "navbar.json" : "footer.json"
+        );
+        const data = (await readJsonFile(filePath)) as TranslationCodeJson;
+        // eslint-disable-next-line security/detect-object-injection -- key comes from the hardcoded GENERIC_TRANSLATABLE_LABELS constant, never external input
+        const entry = data[key];
+        expect(
+          entry,
+          `${locale} ${filePath.split("/").pop()}: missing key "${key}"`
+        ).toBeTruthy();
+        expect(typeof entry.message).toBe("string");
+        expect(entry.message.trim().length).toBeGreaterThan(0);
+        expect(
+          entry.message,
+          `${locale}: "${key}" appears untranslated (message="${entry.message}", expected something like "${hint}")`
+        ).not.toBe(english);
       }
     });
   });

--- a/scripts/verify-locale-output.test.ts
+++ b/scripts/verify-locale-output.test.ts
@@ -147,16 +147,17 @@ const loadDocusaurusBaseEnglishDefaults = async (): Promise<
   const merged: Record<string, string> = {};
   for (const relPath of DOCUSAURUS_BASE_TRANSLATION_FILES) {
     const filePath = path.join(process.cwd(), relPath);
-    try {
-      const content = await fs.readFile(filePath, "utf8");
-      const data = JSON.parse(content) as Record<string, string>;
-      for (const [key, value] of Object.entries(data)) {
-        if (key.endsWith("___DESCRIPTION")) continue;
-        // eslint-disable-next-line security/detect-object-injection -- key comes from a Docusaurus-shipped JSON catalog, never external input
-        merged[key] = value;
-      }
-    } catch {
-      // Translation catalog for a plugin that isn't installed - skip it.
+    // Every file in DOCUSAURUS_BASE_TRANSLATION_FILES corresponds to a
+    // plugin this site has confirmed active in docusaurus.config.ts, so a
+    // read/parse failure here means something is actually broken (missing
+    // dependency, corrupted install) — fail loudly rather than silently
+    // treating the catalog as empty, which would make this check fail-open.
+    const content = await fs.readFile(filePath, "utf8");
+    const data = JSON.parse(content) as Record<string, string>;
+    for (const [key, value] of Object.entries(data)) {
+      if (key.endsWith("___DESCRIPTION")) continue;
+      // eslint-disable-next-line security/detect-object-injection -- key comes from a Docusaurus-shipped JSON catalog, never external input
+      merged[key] = value;
     }
   }
   return merged;
@@ -169,6 +170,21 @@ const ENGLISH_DEFAULT_ALLOWLIST = new Set<string>([
   // "{authorName} - {nPosts}" — just an interpolation pattern, not prose.
   "theme.blog.author.pageTitle",
 ]);
+
+const assertHasAllDocusaurusBaseKeys = (
+  translations: TranslationCodeJson,
+  baseDefaults: Record<string, string>,
+  fileLabel: string
+): void => {
+  const missing = Object.keys(baseDefaults).filter(
+    (key) => !(key in translations)
+  );
+  if (missing.length > 0) {
+    throw new Error(
+      `${fileLabel}: missing ${missing.length} Docusaurus base translation key(s) — these silently fall back to English at runtime:\n${missing.map((k) => `  "${k}"`).join("\n")}`
+    );
+  }
+};
 
 const assertNoUntranslatedDocusaurusDefaults = (
   translations: TranslationCodeJson,
@@ -314,6 +330,7 @@ describe("Locale Output Verification", () => {
       assertNoUntranslatedMessages(codeJson, "es/code.json");
       assertNoEmptyMessages(codeJson, "es/code.json");
       const baseDefaults = await loadDocusaurusBaseEnglishDefaults();
+      assertHasAllDocusaurusBaseKeys(codeJson, baseDefaults, "es/code.json");
       assertNoUntranslatedDocusaurusDefaults(
         codeJson,
         baseDefaults,
@@ -349,6 +366,7 @@ describe("Locale Output Verification", () => {
       assertNoUntranslatedMessages(codeJson, "pt/code.json");
       assertNoEmptyMessages(codeJson, "pt/code.json");
       const baseDefaults = await loadDocusaurusBaseEnglishDefaults();
+      assertHasAllDocusaurusBaseKeys(codeJson, baseDefaults, "pt/code.json");
       assertNoUntranslatedDocusaurusDefaults(
         codeJson,
         baseDefaults,

--- a/scripts/verify-locale-output.test.ts
+++ b/scripts/verify-locale-output.test.ts
@@ -129,38 +129,64 @@ const assertNoEmptyMessages = (
   }
 };
 
-// Docusaurus theme default English strings that are common leak points: a key
-// whose identifier differs from its message (e.g. "theme.TOC.title") slips past
-// assertNoUntranslatedMessages if the message is left as the English default.
-const KNOWN_ENGLISH_THEME_DEFAULTS: Record<string, string> = {
-  "theme.TOC.title": "On this page",
-  "theme.TOCCollapsible.toggleButtonLabel": "On this page",
-  "theme.common.editThisPage": "Edit this page",
-  "theme.docs.paginator.next": "Next",
-  "theme.docs.paginator.previous": "Previous",
-  "theme.CodeBlock.copy": "Copy",
-  "theme.CodeBlock.copied": "Copied",
-  "theme.NotFound.title": "Page Not Found",
-  "theme.BackToTopButton.buttonAriaLabel": "Scroll back to top",
+// Docusaurus theme default English strings are common leak points: a key
+// whose identifier differs from its message (e.g. "theme.TOC.title") slips
+// past assertNoUntranslatedMessages if the message is left as the English
+// default. Rather than a hand-curated sample, load every base English
+// string Docusaurus itself ships for the plugins this site actually uses
+// (see docusaurus.config.ts) and compare the full set.
+const DOCUSAURUS_BASE_TRANSLATION_FILES = [
+  "node_modules/@docusaurus/theme-translations/locales/base/theme-common.json",
+  "node_modules/@docusaurus/theme-translations/locales/base/plugin-pwa.json",
+  "node_modules/@docusaurus/theme-translations/locales/base/plugin-ideal-image.json",
+];
+
+const loadDocusaurusBaseEnglishDefaults = async (): Promise<
+  Record<string, string>
+> => {
+  const merged: Record<string, string> = {};
+  for (const relPath of DOCUSAURUS_BASE_TRANSLATION_FILES) {
+    const filePath = path.join(process.cwd(), relPath);
+    try {
+      const content = await fs.readFile(filePath, "utf8");
+      const data = JSON.parse(content) as Record<string, string>;
+      for (const [key, value] of Object.entries(data)) {
+        if (key.endsWith("___DESCRIPTION")) continue;
+        // eslint-disable-next-line security/detect-object-injection -- key comes from a Docusaurus-shipped JSON catalog, never external input
+        merged[key] = value;
+      }
+    } catch {
+      // Translation catalog for a plugin that isn't installed - skip it.
+    }
+  }
+  return merged;
 };
 
-const assertNoKnownEnglishDefaults = (
+// Keys whose Docusaurus English default is allowed to remain unchanged in
+// es/pt — e.g. brand names, or pure interpolation templates with no literal
+// English words to translate.
+const ENGLISH_DEFAULT_ALLOWLIST = new Set<string>([
+  // "{authorName} - {nPosts}" — just an interpolation pattern, not prose.
+  "theme.blog.author.pageTitle",
+]);
+
+const assertNoUntranslatedDocusaurusDefaults = (
   translations: TranslationCodeJson,
+  baseDefaults: Record<string, string>,
   fileLabel: string
 ): void => {
   const violations: string[] = [];
-  for (const [key, expectedEnglish] of Object.entries(
-    KNOWN_ENGLISH_THEME_DEFAULTS
-  )) {
-    // eslint-disable-next-line security/detect-object-injection -- key comes from the hardcoded KNOWN_ENGLISH_THEME_DEFAULTS map, never external input
+  for (const [key, expectedEnglish] of Object.entries(baseDefaults)) {
+    if (ENGLISH_DEFAULT_ALLOWLIST.has(key)) continue;
+    // eslint-disable-next-line security/detect-object-injection -- key comes from the Docusaurus base translation catalog, never external input
     const entry = translations[key];
-    if (entry && entry.message.trim() === expectedEnglish) {
+    if (entry && entry.message.trim() === expectedEnglish.trim()) {
       violations.push(`  "${key}": still English ("${expectedEnglish}")`);
     }
   }
   if (violations.length > 0) {
     throw new Error(
-      `${fileLabel}: found ${violations.length} untranslated known theme string(s):\n${violations.join("\n")}`
+      `${fileLabel}: found ${violations.length} untranslated Docusaurus default string(s):\n${violations.join("\n")}`
     );
   }
 };
@@ -287,7 +313,12 @@ describe("Locale Output Verification", () => {
       );
       assertNoUntranslatedMessages(codeJson, "es/code.json");
       assertNoEmptyMessages(codeJson, "es/code.json");
-      assertNoKnownEnglishDefaults(codeJson, "es/code.json");
+      const baseDefaults = await loadDocusaurusBaseEnglishDefaults();
+      assertNoUntranslatedDocusaurusDefaults(
+        codeJson,
+        baseDefaults,
+        "es/code.json"
+      );
     });
 
     it("has valid structure with message and optional description", async () => {
@@ -317,7 +348,12 @@ describe("Locale Output Verification", () => {
       );
       assertNoUntranslatedMessages(codeJson, "pt/code.json");
       assertNoEmptyMessages(codeJson, "pt/code.json");
-      assertNoKnownEnglishDefaults(codeJson, "pt/code.json");
+      const baseDefaults = await loadDocusaurusBaseEnglishDefaults();
+      assertNoUntranslatedDocusaurusDefaults(
+        codeJson,
+        baseDefaults,
+        "pt/code.json"
+      );
     });
 
     it("has valid structure with message and optional description", async () => {

--- a/scripts/verify-locale-output.test.ts
+++ b/scripts/verify-locale-output.test.ts
@@ -109,6 +109,62 @@ const assertNoUntranslatedMessages = (
   }
 };
 
+const assertNoEmptyMessages = (
+  translations: TranslationCodeJson,
+  fileLabel: string
+): void => {
+  const violations: string[] = [];
+  for (const [key, entry] of Object.entries(translations)) {
+    if (
+      typeof entry.message !== "string" ||
+      entry.message.trim().length === 0
+    ) {
+      violations.push(`  "${key}"`);
+    }
+  }
+  if (violations.length > 0) {
+    throw new Error(
+      `${fileLabel}: found ${violations.length} empty or missing message(s):\n${violations.join("\n")}`
+    );
+  }
+};
+
+// Docusaurus theme default English strings that are common leak points: a key
+// whose identifier differs from its message (e.g. "theme.TOC.title") slips past
+// assertNoUntranslatedMessages if the message is left as the English default.
+const KNOWN_ENGLISH_THEME_DEFAULTS: Record<string, string> = {
+  "theme.TOC.title": "On this page",
+  "theme.TOCCollapsible.toggleButtonLabel": "On this page",
+  "theme.common.editThisPage": "Edit this page",
+  "theme.docs.paginator.next": "Next",
+  "theme.docs.paginator.previous": "Previous",
+  "theme.CodeBlock.copy": "Copy",
+  "theme.CodeBlock.copied": "Copied",
+  "theme.NotFound.title": "Page Not Found",
+  "theme.BackToTopButton.buttonAriaLabel": "Scroll back to top",
+};
+
+const assertNoKnownEnglishDefaults = (
+  translations: TranslationCodeJson,
+  fileLabel: string
+): void => {
+  const violations: string[] = [];
+  for (const [key, expectedEnglish] of Object.entries(
+    KNOWN_ENGLISH_THEME_DEFAULTS
+  )) {
+    // eslint-disable-next-line security/detect-object-injection -- key comes from the hardcoded KNOWN_ENGLISH_THEME_DEFAULTS map, never external input
+    const entry = translations[key];
+    if (entry && entry.message.trim() === expectedEnglish) {
+      violations.push(`  "${key}": still English ("${expectedEnglish}")`);
+    }
+  }
+  if (violations.length > 0) {
+    throw new Error(
+      `${fileLabel}: found ${violations.length} untranslated known theme string(s):\n${violations.join("\n")}`
+    );
+  }
+};
+
 const NAVBAR_EXPECTED_KEYS = [
   "item.label.Documentation",
   "item.label.GitHub",
@@ -230,6 +286,8 @@ describe("Locale Output Verification", () => {
         "es/code.json"
       );
       assertNoUntranslatedMessages(codeJson, "es/code.json");
+      assertNoEmptyMessages(codeJson, "es/code.json");
+      assertNoKnownEnglishDefaults(codeJson, "es/code.json");
     });
 
     it("has valid structure with message and optional description", async () => {
@@ -258,6 +316,8 @@ describe("Locale Output Verification", () => {
         "pt/code.json"
       );
       assertNoUntranslatedMessages(codeJson, "pt/code.json");
+      assertNoEmptyMessages(codeJson, "pt/code.json");
+      assertNoKnownEnglishDefaults(codeJson, "pt/code.json");
     });
 
     it("has valid structure with message and optional description", async () => {


### PR DESCRIPTION
## Summary

Companion PR to [digidem/comapeo-content-pipeline#6](https://github.com/digidem/comapeo-content-pipeline/pull/6) (**merged**), which fixes the *content*-side cause of untranslated ES/PT sidebar headers (a new canonical hierarchy engine in the content pipeline). This PR fixes the *theme*-side half: Docusaurus UI chrome — navbar, footer, and generic `code.json` strings (breadcrumbs, search, pagination, section/category labels sourced from Notion Title/Toggle rows) — were either plain English or, for pipeline-sourced labels, carried Docusaurus's own generic `write-translations` placeholders ("Nueva Página", "Nuevo título de sección", "Nueva Palanca") instead of real translated content.

- Adds `i18n/{es,pt}/docusaurus-theme-classic/{navbar,footer}.json` with translated navbar item labels (including `logo.alt`) and footer section/link labels, in both Docusaurus's actual runtime key format (`link.title.*`, `link.item.label.*`) and a legacy format kept for backward compatibility.
- Replaces placeholder/English messages in `i18n/{es,pt}/code.json` with real ES/PT translations, covering all ~90 active Docusaurus base theme keys (theme-common, plugin-pwa, plugin-ideal-image) plus Notion-sourced content labels.
- Rewrites `scripts/verify-locale-output.test.ts`'s untranslated-string detection to dynamically compare every locale message against Docusaurus's own shipped English catalogs (instead of a small hand-picked sample), fail-closed on both missing keys and catalog load errors.
- **Changes 4 CI/deploy workflows** (`test.yml`, `deploy-pr-preview.yml`, `deploy-production.yml`, `deploy-staging.yml`): each checks out `i18n/` from the `content` branch (or a locked content SHA) before running tests or building, which would otherwise silently discard this repo's hand-maintained theme translation files. All four now restore `i18n/*/code.json` and `i18n/*/docusaurus-theme-classic/*` from the ref actually being built/tested immediately after that overlay. Per `AGENTS.md`'s "do not modify CI without approval" — flagging this explicitly for maintainer sign-off.
- Selectively un-ignores the new theme-classic files in `.gitignore` (previously the whole `/i18n/` tree was fully generated/ignored) and fixes the `translate-docs.yml` content-sync `sed` step that adjusts it, while leaving the rest of `i18n/` — regenerated per-sync from the content pipeline — untouched.

Since both PRs are now merged, sidebar category structure/content (pipeline PR) and the surrounding theme chrome (this PR) should both be covered once `content` re-syncs against the merged pipeline output.

### Review process

Went through 3 rounds of an automated PR-readiness loop (Codex, gpt-5.6-sol) plus an independent second-opinion pass (Fable 5). Real issues found and fixed along the way:
- Navbar `logo.alt` extraction was missing from the generator — would've been silently dropped on next regeneration.
- The 4 workflow files above needed the i18n-restore fix — CI was validating this PR's own locale files, but a regression check found the *first version* of that fix only worked inside PR check runs: it went silent on a bare push to `main` (post-merge) and was entirely absent from the production/staging deploy workflows, which would have let this PR's actual payload (translated `code.json`) never reach real users. Fixed with a simpler, unconditional restore that doesn't depend on diffing.
- The untranslated-string check's coverage gap (9 keys → ~90) also turned out to be fail-open on first pass (didn't catch keys *missing* entirely, only present-but-untranslated ones) — caught 3 real missing PWA translation keys as a result, now added using Docusaurus's own official ES/pt-BR strings.

### Known non-blocking limitations

- `i18n/{es,pt}/docusaurus-theme-classic/footer.json`'s copyright message is a static snapshot ("... - 2026") — Docusaurus's English default uses a live `${new Date().getFullYear()}`, but translated locale JSON catalogs can't hold a JS expression, so these will need a manual bump (or theme-chrome regeneration) at the next year boundary.
- `verify-locale-output.test.ts`'s es/pt key-count parity check still tolerates ~10% drift — loose enough that a handful of Notion-content keys could differ between locales without failing. Left as-is since tightening it risks false positives unrelated to this PR's scope.

## Test plan

- [x] `scripts/locale-parity.test.ts` and `scripts/verify-locale-output.test.ts` — 35/35 passing, asserting no placeholder/empty/untranslated messages, full Docusaurus base-catalog coverage (fail-closed on missing keys), matching key counts across locales, and expected theme-translation keys
- [x] Full project suite (`bun run test`) — 2113/2113 passing (96 files, 8 skipped live/integration tests requiring real API credentials)
- [x] `eslint` + `tsc --noEmit` on all changed files — zero errors, zero warnings
- [x] Manually simulated the post-merge `main`-push CI failure mode and confirmed the fix resolves it (content overlay → 65 keys, restore → full 159-key set, clean `git status` against HEAD)
- [x] Verified locally: rebuilt this branch against a fresh pipeline-generated corpus and confirmed in a live Docusaurus build/browser check that navbar, footer, breadcrumbs, and sidebar categories all render translated in ES and PT
- [x] All CI checks green on the final commit (`f8c87b1`); PR is `MERGEABLE` with `mergeStateStatus: CLEAN`

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds translated Docusaurus UI chrome for Spanish and Portuguese. The main changes are:

- ES/PT `code.json` catalogs now replace placeholder and English theme messages.
- ES/PT navbar and footer theme catalogs are added for Docusaurus runtime keys.
- CI and deploy workflows restore repo-owned theme translations after content-branch overlays.
- Locale verification now checks Docusaurus base keys, untranslated defaults, placeholders, and expected theme files.
- `.gitignore` and content-sync handling now keep generated i18n ignored while allowing tracked theme JSON files.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

Changed workflows, locale catalogs, and tests align with the repo's generated-content and i18n flow. Prior issues around ignored generated files and destructive `code.json` restores are addressed. No accepted issues remain.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Validated Spanish localization by inspecting the ES home page image, ES docs page image, and the ES Playwright video artifact.
- Validated Portuguese localization by inspecting the PT home page image, PT docs page image, and the PT Playwright video artifact.
- Reviewed the runtime artifacts, including dev-server logs for ES and PT and the Playwright outputs, to verify end-to-end test execution surfaced in the build.

<a href="https://app.greptile.com/trex/runs/15007852/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-production.yml | Restores theme locale files after locked content checkout, merges `code.json`, and scopes the content-lock commit to avoid committing overlaid locale state. |
| .github/workflows/test.yml | CI tests now overlay content i18n, restore tracked theme catalogs, and merge `code.json` before running locale-dependent tests. |
| .github/workflows/translate-docs.yml | Updates content-branch `.gitignore` adjustment to remove the new i18n allowlist block before committing generated translations. |
| .gitignore | Keeps generated docs/images ignored while selectively unignoring ES/PT theme-classic navbar and footer translation JSON. |
| i18n/es/code.json | Replaces Spanish placeholder strings and adds Docusaurus base theme/PWA/ideal-image translation keys. |
| i18n/es/docusaurus-theme-classic/footer.json | Adds Spanish footer translation catalog in legacy and Docusaurus runtime key formats. |
| i18n/pt/code.json | Replaces Portuguese placeholder strings and adds Docusaurus base theme/PWA/ideal-image translation keys. |
| i18n/pt/docusaurus-theme-classic/footer.json | Adds Portuguese footer translation catalog in legacy and Docusaurus runtime key formats. |
| scripts/notion-translate/translateCodeJson.ts | Extends translation extraction to include Docusaurus runtime navbar/footer keys, including `logo.alt`. |
| scripts/verify-locale-output.test.ts | Broadens locale verification to catch placeholders, missing Docusaurus base keys, untranslated defaults, and expected theme catalog keys. |

</details>


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant BuildRef as PR/main ref
participant Content as content branch or locked SHA
participant Workflow as CI/deploy workflow
participant I18n as i18n/** working tree
participant Tests as Locale tests / Docusaurus build

Workflow->>Content: checkout docs/, i18n/, static/images/
Content-->>I18n: generated localized docs + content code.json keys
Workflow->>BuildRef: "restore i18n/*/docusaurus-theme-classic/*"
BuildRef-->>I18n: repo-owned navbar/footer catalogs
Workflow->>BuildRef: "read HEAD i18n/*/code.json"
Workflow->>I18n: validate JSON objects and merge content + HEAD code.json
I18n->>Tests: translated theme chrome + content labels
Tests-->>Workflow: locale verification/build result
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant BuildRef as PR/main ref
participant Content as content branch or locked SHA
participant Workflow as CI/deploy workflow
participant I18n as i18n/** working tree
participant Tests as Locale tests / Docusaurus build

Workflow->>Content: checkout docs/, i18n/, static/images/
Content-->>I18n: generated localized docs + content code.json keys
Workflow->>BuildRef: "restore i18n/*/docusaurus-theme-classic/*"
BuildRef-->>I18n: repo-owned navbar/footer catalogs
Workflow->>BuildRef: "read HEAD i18n/*/code.json"
Workflow->>I18n: validate JSON objects and merge content + HEAD code.json
I18n->>Tests: translated theme chrome + content labels
Tests-->>Workflow: locale verification/build result
```

</a>

<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (5)</h3></summary>

1. `scripts/verify-locale-output.test.ts`, line 294-298 ([link](https://github.com/digidem/comapeo-docs/blob/8aecfc8a6981e33f19d4d391445cc63bf63ed0a0/scripts/verify-locale-output.test.ts#L294-L298)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Locale Key Drift Passes Verification**

   With the current 156 keys, this threshold allows up to 16 keys to exist in only one locale. If generation omits several Portuguese labels while Spanish succeeds, the test passes and Portuguese pages fall back to English for those labels.

   **Context Used:** AGENTS.md ([source](https://app.greptile.com/awana-digital/github/digidem/comapeo-docs/-/custom-context?memory=ca3c2441-375f-4d23-944a-2910a76252b7))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: scripts/verify-locale-output.test.ts
   Line: 294-298
   
   Comment:
   **Locale Key Drift Passes Verification**
   
   With the current 156 keys, this threshold allows up to 16 keys to exist in only one locale. If generation omits several Portuguese labels while Spanish succeeds, the test passes and Portuguese pages fall back to English for those labels.
   
   **Context Used:** AGENTS.md ([source](https://app.greptile.com/awana-digital/github/digidem/comapeo-docs/-/custom-context?memory=ca3c2441-375f-4d23-944a-2910a76252b7))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Localized documentation pages still render English sidebar and breadcrumb category labels**

   - **Bug**
     - On the real changed Spanish page `/es/docs/introduction`, the breadcrumb renders `Overview / Introducción` and the sidebar renders English categories including `Overview`, `Customizing CoMapeo`, `Gathering Observations & Tracks`, `Managing Projects`, and `Troubleshooting`. The Portuguese browser assertion also failed because `Visão Geral` was not rendered. This contradicts the stated localized breadcrumb/sidebar behavior while navbar and footer localization works.
   - **Cause**
     - The visible autogenerated category labels are sourced from the English docs category metadata rather than the translated locale category metadata or translated `code.json` entries. The changed `code.json` messages exist but are not applied to these rendered category labels.
   - **Fix**
     - Ensure localized docs resolve `_category_.json` from `i18n/<locale>/docusaurus-plugin-content-docs/current`, or generate/use translated category metadata in the sidebar. Add a browser assertion that the ES breadcrumb/sidebar includes `Vista General` and the PT equivalent includes `Visão Geral`, while representative English category labels are absent.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

3. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Localized documentation pages still render English breadcrumb and sidebar category labels**

   - **Bug**
     - On the real `/es/docs/introduction` and `/pt/docs/introduction` pages, the visible breadcrumb begins with `Overview` and the desktop sidebar categories remain English, including `Overview`, `Customizing CoMapeo`, `Gathering Observations & Tracks`, `Reviewing Observations`, and other categories. This contradicts the stated live-browser result that breadcrumb and sidebar categories are translated. Navbar, footer, and generic breadcrumb ARIA text are localized correctly.
   - **Cause**
     - The translated catalogs do not match or override the category metadata used by the active autogenerated sidebar. Although localized `_category_.json` files exist, their directory/category structure differs from the categories actually rendered by the current documentation corpus, so Docusaurus continues using English category labels.
   - **Fix**
     - Ensure every active source-doc category has a path-matching localized `_category_.json` in each locale, or generate localized category metadata against the exact current `docs/` hierarchy. Add browser/output assertions for the actual rendered category routes—not only catalog key parity—and verify `Overview` plus at least one additional category is localized in both ES and PT.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

4. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Portuguese documentation sidebar and breadcrumb still render English category labels**

   - **Bug**
     - On the real `/pt/docs/introduction` page, the visible breadcrumb is `Overview > Introdução`, and most sidebar categories remain English. This produces mixed-language documentation chrome despite the Portuguese strings added to `i18n/pt/code.json`. Navbar, footer, and generic ARIA labels localize correctly.
   - **Cause**
     - The category translations added as arbitrary entries in `i18n/pt/code.json` are present in Docusaurus code translations but are not applied to metadata-derived labels in the autogenerated docs sidebar. Runtime sidebar data continues to use category labels from the default English docs metadata.
   - **Fix**
     - Provide the category-label translations through the Docusaurus docs plugin’s generated translation mechanism used by autogenerated sidebars, or otherwise configure sidebar/category metadata so the localized `_category_.json` labels are consumed. Re-run the PT page and assert that both breadcrumb text and all visible category labels are Portuguese.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

5. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Localized documentation sidebar and breadcrumbs still render English category labels**

   - **Bug**
     - On the real ES page, the rendered breadcrumb is `Overview Introducción` and the sidebar includes `Overview`, `Customizing CoMapeo`, `Gathering Observations & Tracks`, and other English labels. The PT page likewise renders `Overview Introdução` and the same English sidebar categories. This contradicts the stated localization objective even though navbar/footer localization works.
   - **Cause**
     - The translated category strings added to `i18n/es/code.json` and `i18n/pt/code.json` are not the catalog entries Docusaurus consumes for autogenerated documentation category metadata. The locale tree lacks the appropriate `docusaurus-plugin-content-docs/current.json` translation catalog, so Docusaurus falls back to category metadata from the English source docs. The updated tests only inspect catalog contents and non-empty `_category_.json` labels; they do not prove those values are used at runtime.
   - **Fix**
     - Generate and commit the Docusaurus content-docs translation catalog for each locale—normally `i18n/<locale>/docusaurus-plugin-content-docs/current.json` from `docusaurus write-translations`—and translate its category label keys. Add browser-level or generated-output assertions that the rendered sidebar and breadcrumb contain `Vista General`/`Visão Geral` and other localized categories rather than English source labels.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (9): Last reviewed commit: ["fix(ci): reject malformed code.json inst..."](https://github.com/digidem/comapeo-docs/commit/a9118af80505d9b43ec2c54693ffcf9d9144014e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44576233)</sub>

<!-- /greptile_comment -->