### PR TITLE
ci: wire generated-content policy guard + deploy concurrency guard

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -30,6 +30,10 @@ on:
       - "**.md"
       - "docs/**"
 
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false
+
 jobs:
   deploy:
     name: Deploy to Cloudflare Pages and Update Notion

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,9 @@ jobs:
         with:
           bun-version: latest
 
+      - name: Verify generated-content policy
+        run: bun scripts/verify-generated-content-policy.ts
+
       - name: Checkout i18n content from content branch
         id: i18n_content
         shell: bash

--- a/package.json
+++ b/package.json
@@ -58,7 +58,9 @@
     "write-heading-ids": "docusaurus write-heading-ids",
     "gen-pdf": "docusaurus-prince-pdf -u http://localhost:3000/docs",
     "typecheck": "tsc",
-    "test:locale-parity": "vitest --run scripts/locale-parity.test.ts"
+    "test:locale-parity": "vitest --run scripts/locale-parity.test.ts",
+    "test:content-policy": "vitest --run scripts/verify-generated-content-policy.test.ts",
+    "verify:generated-content-policy": "bun scripts/verify-generated-content-policy.ts"
   },
   "dependencies": {
     "@docusaurus/core": "^3.10.1",

--- a/scripts/verify-generated-content-policy.test.ts
+++ b/scripts/verify-generated-content-policy.test.ts
@@ -1,111 +1,156 @@
 /**
  * Tests for verify-generated-content-policy script
+ *
+ * These tests exercise the REAL implementation by importing it directly.
+ * Importing the module is safe here: its top-level `main()` call is guarded
+ * by `if (import.meta.main)`, which is false for imported modules under
+ * vitest, so no git commands run at import time.
  */
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 
-// Mock module functions
-const mockGetTrackedFilesInDirectory = vi.fn(() => Promise.resolve([]));
-const mockCheckDirectoryPolicy = vi.fn(() =>
-  Promise.resolve({ isCompliant: true, violations: [] })
-);
+// The policy script imports `$` from Bun's shell. Under vitest's Node
+// runtime there is no installable "bun" package, so mock the module. The
+// mock is never actually invoked: these tests only exercise isAllowedFile
+// and GENERATED_DIRECTORIES, and main() (the sole caller of $) is guarded
+// by `import.meta.main`, which is false for imported modules.
+vi.mock("bun", () => ({
+  $: () => {
+    throw new Error("bun shell is not available under vitest");
+  },
+}));
 
-// Mock the actual implementation
-const GENERATED_DIRECTORIES = [
-  {
-    path: "docs",
-    description: "Generated documentation files",
-    allowedPatterns: [
-      /\.gitkeep$/,
-      /^docs\/developer-tools\/.*/, // Hand-crafted developer documentation
-    ],
-  },
-  {
-    path: "i18n",
-    description: "Generated translations",
-    allowedPatterns: [/\.gitkeep$/, /\/code\.json$/],
-  },
-  {
-    path: "static/images",
-    description: "Downloaded images from Notion",
-    allowedPatterns: [/\.gitkeep$/, /\.emoji-cache\.json$/],
-  },
-];
+import {
+  GENERATED_DIRECTORIES,
+  isAllowedFile,
+} from "./verify-generated-content-policy";
+
+const docsConfig = GENERATED_DIRECTORIES.find((d) => d.path === "docs")!;
+const i18nConfig = GENERATED_DIRECTORIES.find((d) => d.path === "i18n")!;
+const imagesConfig = GENERATED_DIRECTORIES.find(
+  (d) => d.path === "static/images"
+)!;
 
 describe("verify-generated-content-policy", () => {
   describe("isAllowedFile", () => {
-    function isAllowedFile(
-      filePath: string,
-      allowedPatterns: RegExp[]
-    ): boolean {
-      return allowedPatterns.some((pattern) => pattern.test(filePath));
-    }
-
     it("should allow .gitkeep files in docs directory", () => {
-      expect(
-        isAllowedFile("docs/.gitkeep", [
-          /\.gitkeep$/,
-          /^docs\/developer-tools\/.*/,
-        ])
-      ).toBe(true);
+      expect(isAllowedFile("docs/.gitkeep", docsConfig.allowedPatterns)).toBe(
+        true
+      );
     });
 
     it("should allow .gitkeep files in i18n directory", () => {
-      expect(
-        isAllowedFile("i18n/.gitkeep", [/\.gitkeep$/, /\/code\.json$/])
-      ).toBe(true);
+      expect(isAllowedFile("i18n/.gitkeep", i18nConfig.allowedPatterns)).toBe(
+        true
+      );
     });
 
     it("should allow code.json files in i18n directory", () => {
       expect(
-        isAllowedFile("i18n/es/code.json", [/\.gitkeep$/, /\/code\.json$/])
+        isAllowedFile("i18n/es/code.json", i18nConfig.allowedPatterns)
       ).toBe(true);
       expect(
-        isAllowedFile("i18n/pt/code.json", [/\.gitkeep$/, /\/code\.json$/])
+        isAllowedFile("i18n/pt/code.json", i18nConfig.allowedPatterns)
       ).toBe(true);
     });
 
     it("should allow .emoji-cache.json in static/images directory", () => {
       expect(
-        isAllowedFile("static/images/.emoji-cache.json", [
-          /\.gitkeep$/,
-          /\.emoji-cache\.json$/,
-        ])
+        isAllowedFile(
+          "static/images/.emoji-cache.json",
+          imagesConfig.allowedPatterns
+        )
       ).toBe(true);
     });
 
     it("should allow developer-tools files but reject other content in docs directory", () => {
-      const patterns = [/\.gitkeep$/, /^docs\/developer-tools\/.*/];
       expect(
-        isAllowedFile("docs/developer-tools/api-reference.md", patterns)
+        isAllowedFile(
+          "docs/developer-tools/api-reference.md",
+          docsConfig.allowedPatterns
+        )
       ).toBe(true);
       expect(
-        isAllowedFile("docs/developer-tools/cli-reference.md", patterns)
+        isAllowedFile(
+          "docs/developer-tools/cli-reference.md",
+          docsConfig.allowedPatterns
+        )
       ).toBe(true);
       expect(
-        isAllowedFile("docs/developer-tools/_category_.json", patterns)
+        isAllowedFile(
+          "docs/developer-tools/_category_.json",
+          docsConfig.allowedPatterns
+        )
       ).toBe(true);
       // Non-developer-tools content should still be rejected
-      expect(isAllowedFile("docs/introduction.md", patterns)).toBe(false);
-      expect(isAllowedFile("docs/user-guide.md", patterns)).toBe(false);
+      expect(
+        isAllowedFile("docs/introduction.md", docsConfig.allowedPatterns)
+      ).toBe(false);
+      expect(
+        isAllowedFile("docs/user-guide.md", docsConfig.allowedPatterns)
+      ).toBe(false);
     });
 
     it("should reject content translation files in i18n directory", () => {
       expect(
         isAllowedFile(
           "i18n/es/docusaurus-plugin-content-docs/current/api-reference.md",
-          [/\.gitkeep$/, /\/code\.json$/]
+          i18nConfig.allowedPatterns
         )
       ).toBe(false);
     });
 
     it("should reject image files in static/images directory", () => {
       expect(
-        isAllowedFile("static/images/notion/test.png", [
-          /\.gitkeep$/,
-          /\.emoji-cache\.json$/,
-        ])
+        isAllowedFile(
+          "static/images/notion/test.png",
+          imagesConfig.allowedPatterns
+        )
       ).toBe(false);
+    });
+  });
+
+  describe("theme translation file exceptions", () => {
+    const i18nPatterns = i18nConfig.allowedPatterns;
+
+    it("should allow the hand-maintained docusaurus-theme-classic navbar/footer files", () => {
+      expect(
+        isAllowedFile(
+          "i18n/es/docusaurus-theme-classic/navbar.json",
+          i18nPatterns
+        )
+      ).toBe(true);
+      expect(
+        isAllowedFile(
+          "i18n/es/docusaurus-theme-classic/footer.json",
+          i18nPatterns
+        )
+      ).toBe(true);
+      expect(
+        isAllowedFile(
+          "i18n/pt/docusaurus-theme-classic/navbar.json",
+          i18nPatterns
+        )
+      ).toBe(true);
+      expect(
+        isAllowedFile(
+          "i18n/pt/docusaurus-theme-classic/footer.json",
+          i18nPatterns
+        )
+      ).toBe(true);
+    });
+
+    it("should reject neighboring theme files that are not navbar/footer", () => {
+      expect(
+        isAllowedFile(
+          "i18n/es/docusaurus-theme-classic/other.json",
+          i18nPatterns
+        )
+      ).toBe(false);
+    });
+
+    it("should still allow code.json alongside the theme exceptions", () => {
+      expect(isAllowedFile("i18n/es/code.json", i18nPatterns)).toBe(true);
     });
   });
 
@@ -126,10 +171,34 @@ describe("verify-generated-content-policy", () => {
 
     it("should have proper allowed patterns for i18n directory", () => {
       const i18nConfig = GENERATED_DIRECTORIES.find((d) => d.path === "i18n");
-      expect(i18nConfig?.allowedPatterns).toEqual([
-        /\.gitkeep$/,
-        /\/code\.json$/,
-      ]);
+      // Three patterns: .gitkeep, code.json, and the theme navbar/footer
+      // exception. RegExp instances can't be compared by reference, so assert
+      // the count here and validate behavior via sample paths.
+      expect(i18nConfig?.allowedPatterns).toHaveLength(3);
+      expect(isAllowedFile("i18n/.gitkeep", i18nConfig!.allowedPatterns)).toBe(
+        true
+      );
+      expect(
+        isAllowedFile("i18n/es/code.json", i18nConfig!.allowedPatterns)
+      ).toBe(true);
+      expect(
+        isAllowedFile(
+          "i18n/es/docusaurus-theme-classic/navbar.json",
+          i18nConfig!.allowedPatterns
+        )
+      ).toBe(true);
+      expect(
+        isAllowedFile(
+          "i18n/es/docusaurus-theme-classic/footer.json",
+          i18nConfig!.allowedPatterns
+        )
+      ).toBe(true);
+      expect(
+        isAllowedFile(
+          "i18n/es/docusaurus-theme-classic/other.json",
+          i18nConfig!.allowedPatterns
+        )
+      ).toBe(false);
     });
 
     it("should have proper allowed patterns for static/images directory", () => {
@@ -143,23 +212,6 @@ describe("verify-generated-content-policy", () => {
     });
   });
 
-  describe("getTrackedFilesInDirectory", () => {
-    it("should return empty array when git command fails", async () => {
-      // Mock implementation would return empty on error
-      const mockResult = mockGetTrackedFilesInDirectory();
-      await expect(mockResult).resolves.toEqual([]);
-    });
-
-    it("should return file list when directory has tracked files", async () => {
-      // Mock implementation would return array of files
-      mockGetTrackedFilesInDirectory.mockResolvedValueOnce([
-        "docs/api-reference.md",
-      ]);
-      const result = await mockGetTrackedFilesInDirectory();
-      expect(result).toEqual(["docs/api-reference.md"]);
-    });
-  });
-
   describe("Policy compliance scenarios", () => {
     it("should be compliant when only .gitkeep and developer-tools files are present", () => {
       const files = [
@@ -168,14 +220,9 @@ describe("verify-generated-content-policy", () => {
         "docs/developer-tools/cli-reference.md",
         "docs/developer-tools/_category_.json",
       ];
-      const violations: string[] = [];
-      const allowedPatterns = [/\.gitkeep$/, /^docs\/developer-tools\/.*/];
-
-      for (const file of files) {
-        if (!allowedPatterns.some((pattern) => pattern.test(file))) {
-          violations.push(file);
-        }
-      }
+      const violations = files.filter(
+        (file) => !isAllowedFile(file, docsConfig.allowedPatterns)
+      );
 
       expect(violations).toHaveLength(0);
     });
@@ -187,34 +234,26 @@ describe("verify-generated-content-policy", () => {
         "docs/introduction.md",
         "docs/user-guide.md",
       ];
-      const violations: string[] = [];
-      const allowedPatterns = [/\.gitkeep$/, /^docs\/developer-tools\/.*/];
-
-      for (const file of files) {
-        if (!allowedPatterns.some((pattern) => pattern.test(file))) {
-          violations.push(file);
-        }
-      }
+      const violations = files.filter(
+        (file) => !isAllowedFile(file, docsConfig.allowedPatterns)
+      );
 
       expect(violations).toHaveLength(2);
       expect(violations).toContain("docs/introduction.md");
       expect(violations).toContain("docs/user-guide.md");
     });
 
-    it("should allow code.json in i18n but not content files", () => {
+    it("should allow code.json and theme files in i18n but not content files", () => {
       const files = [
         "i18n/es/code.json",
         "i18n/pt/code.json",
+        "i18n/es/docusaurus-theme-classic/navbar.json",
+        "i18n/pt/docusaurus-theme-classic/footer.json",
         "i18n/es/docusaurus-plugin-content-docs/current/intro.md",
       ];
-      const violations: string[] = [];
-      const allowedPatterns = [/\.gitkeep$/, /\/code\.json$/];
-
-      for (const file of files) {
-        if (!allowedPatterns.some((pattern) => pattern.test(file))) {
-          violations.push(file);
-        }
-      }
+      const violations = files.filter(
+        (file) => !isAllowedFile(file, i18nConfig.allowedPatterns)
+      );
 
       expect(violations).toHaveLength(1);
       expect(violations[0]).toBe(
@@ -229,15 +268,9 @@ describe("verify-generated-content-policy", () => {
         "docs/developer-tools/_category_.json",
         "docs/developer-tools/testing-guide.md",
       ];
-      const allowedPatterns = [/\.gitkeep$/, /^docs\/developer-tools\/.*/];
-
-      // Use the same helper function from the isAllowedFile tests
-      function isAllowedFile(filePath: string, patterns: RegExp[]): boolean {
-        return patterns.some((pattern) => pattern.test(filePath));
-      }
 
       for (const file of developerToolsFiles) {
-        expect(isAllowedFile(file, allowedPatterns)).toBe(true);
+        expect(isAllowedFile(file, docsConfig.allowedPatterns)).toBe(true);
       }
     });
   });

--- a/scripts/verify-generated-content-policy.ts
+++ b/scripts/verify-generated-content-policy.ts
@@ -16,7 +16,6 @@
 //
 // Exits with code 1 if policy violations are found.
 
-// eslint-disable-next-line import/no-unresolved
 import { $ } from "bun";
 import path from "node:path";
 
@@ -31,7 +30,7 @@ interface PolicyCheckResult {
   violations: PolicyViolation[];
 }
 
-const GENERATED_DIRECTORIES = [
+export const GENERATED_DIRECTORIES = [
   {
     path: "docs",
     description: "Generated documentation files",
@@ -46,6 +45,7 @@ const GENERATED_DIRECTORIES = [
     allowedPatterns: [
       /\.gitkeep$/,
       /\/code\.json$/, // UI translation strings are allowed
+      /^i18n\/[^/]+\/docusaurus-theme-classic\/(navbar|footer)\.json$/, // Hand-maintained theme chrome translations
     ],
   },
   {
@@ -57,7 +57,8 @@ const GENERATED_DIRECTORIES = [
 
 async function getTrackedFilesInDirectory(dirPath: string): Promise<string[]> {
   try {
-    const result = await $`git ls-files ${dirPath}`.quiet();
+    const result =
+      await $`git ls-tree -r --name-only HEAD -- ${dirPath}`.quiet();
     if (result.exitCode !== 0) {
       return [];
     }
@@ -67,7 +68,10 @@ async function getTrackedFilesInDirectory(dirPath: string): Promise<string[]> {
   }
 }
 
-function isAllowedFile(filePath: string, allowedPatterns: RegExp[]): boolean {
+export function isAllowedFile(
+  filePath: string,
+  allowedPatterns: RegExp[]
+): boolean {
   return allowedPatterns.some((pattern) => pattern.test(filePath));
 }
 


### PR DESCRIPTION
Recurrence prevention for the July production image bugs (follow-up to #196).

## Guard (verify-generated-content-policy)

The script existed but was dormant (never wired into CI). This wires it in and fixes two gaps:

- **allowedPatterns gap**: now permits exactly the 4 hand-maintained `i18n/*/docusaurus-theme-classic/{navbar,footer}.json` theme files. Without this, the guard false-positives on the clean `main` produced by #196 (which tracks those 4 + 2 code.json). A neighboring `docusaurus-theme-classic/other.json` is still rejected.
- **Index-pollution gap**: reads `git ls-tree -r HEAD` instead of `git ls-files`. `test.yml` overlays generated `i18n/` into the index via `git checkout origin/content -- i18n/`; reading the mutable index would report hundreds of generated paths as violations on a clean main. Reading HEAD is immune regardless of step ordering (step is also placed before the overlay, belt-and-suspenders).
- **Regression test**: the test now imports the real `GENERATED_DIRECTORIES`/`isAllowedFile` (they were duplicated inline, so changing the real patterns left tests green) and proves the 4 theme files pass while `other.json` is rejected.

## Concurrency guard (deploy-production.yml)

Adds a workflow-unique `concurrency` group (`deploy-production`, `cancel-in-progress: false`) so overlapping production deploys **queue** rather than race and clobber each other's Cloudflare Pages output. Unique group name so it doesn't collide with `clean-content.yml`; `cancel-in-progress: false` so an in-flight deploy is never killed mid-push.

## Verification

- `bun scripts/verify-generated-content-policy.ts` → 0 violations (clean main), exit 0
- `bun run test:content-policy` → 18/18 pass (verified under the Bun runtime, matching CI)
- `bun run typecheck` → exit 0
- Both workflow YAMLs parse

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR activates and strengthens generated-content policy checks while serializing runs of the production deployment workflow.
- Runs the generated-content verifier in CI before the content-branch overlay.
- Reads committed paths from HEAD and permits hand-maintained theme translation files.
- Tests the exported production policy configuration directly and adds package scripts for verification.
- Queues overlapping runs of the production deployment workflow instead of cancelling active deployments.

<h3>Confidence Score: 4/5</h3>

The PR is safe to merge, with non-blocking allowlist scoping and deployment queue concerns worth addressing.

The verifier accepts theme files for locales outside the intended Spanish and Portuguese set, and the static deployment group allows test-environment runs to delay production deployments.

scripts/verify-generated-content-policy.ts and .github/workflows/deploy-production.yml

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The temporary index now contains the forbidden other.json, while HEAD does not.
- The guard remained compliant and exited with status 0 for the check.
- All supporting commands completed with exit code 0, including clean guard, 18 focused tests, typecheck, workflow parse, and cleanup verification.

<a href="https://app.greptile.com/trex/runs/15558137/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| scripts/verify-generated-content-policy.ts | Switches policy inspection to HEAD and exports the policy helpers, but the new theme exception accepts locales beyond the intended es/pt set. |
| scripts/verify-generated-content-policy.test.ts | Replaces duplicated test logic with direct tests of the production policy and covers allowed theme filenames. |
| .github/workflows/test.yml | Runs the generated-content policy guard before the mutable i18n overlay. |
| .github/workflows/deploy-production.yml | Adds workflow-level serialization, but the static group also queues test-environment runs ahead of production deployments. |
| package.json | Adds explicit scripts for policy tests and direct policy verification. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
Commit[Checked-out HEAD] --> Guard[Generated-content policy guard]
Guard -->|passes| Overlay[Overlay i18n from content branch]
Overlay --> Tests[Run test suite]
Trigger[Production workflow trigger] --> Queue[deploy-production concurrency queue]
Queue --> Deploy[Cloudflare Pages deployment]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 2 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 2
scripts/verify-generated-content-policy.ts:48
**Theme allowlist accepts every locale**

The `[^/]+` locale wildcard permits tracked navbar and footer files outside the intended `es` and `pt` set, so a force-added path such as `i18n/fr/docusaurus-theme-classic/navbar.json` passes CI despite falling outside the four-file policy exception. Restrict this component to `es|pt` and add a negative test for another locale.

### Issue 2 of 2
.github/workflows/deploy-production.yml:33-35
**Test runs block production deploys**

This static group also serializes manual `environment: test` runs, so a long-running test deployment queues an urgent production push or dispatch until it finishes. Scope the group by environment or place test deployments in a separate group while retaining serialization among production runs.

`````

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: wire generated-content policy guard ..."](https://github.com/digidem/comapeo-docs/commit/355c0634d136450d77cb6870e861896a107ca9b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46624540)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->