### PR TITLE
ci: address #197 review feedback (locale-pinned theme regex, env-scoped concurrency)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -30,8 +30,20 @@ on:
       - "**.md"
       - "docs/**"
 
+# Serialize deploys so overlapping runs can't race and clobber each other's
+# Cloudflare Pages output. The group is scoped by environment so a long-running
+# `environment: test` deploy cannot queue/block an urgent production deploy
+# (and vice-versa); runs of the same environment serialize among themselves.
+# `cancel-in-progress: false` means an in-flight deploy is never killed mid-push.
+#
+# We intentionally keep GitHub's default single pending slot (no `queue: max`):
+# for production content deploys the desired semantic is latest-wins — if several
+# deploys are dispatched back-to-back, only the newest queued one runs after the
+# in-flight one finishes. A dropped intermediate deploy is superseded anyway (its
+# content SHA and Notion status update are both overtaken by the newer run), so
+# `queue: max` would only burn time deploying stale intermediate content.
 concurrency:
-  group: deploy-production
+  group: deploy-${{ inputs.environment || 'production' }}
   cancel-in-progress: false
 
 jobs:

--- a/scripts/verify-generated-content-policy.test.ts
+++ b/scripts/verify-generated-content-policy.test.ts
@@ -149,6 +149,24 @@ describe("verify-generated-content-policy", () => {
       ).toBe(false);
     });
 
+    it("should reject theme files for locales outside the es/pt exception", () => {
+      // The exception is pinned to the es/pt locales this repo actually
+      // hand-maintains; a force-added theme file for another locale must
+      // still be flagged as a policy violation.
+      expect(
+        isAllowedFile(
+          "i18n/fr/docusaurus-theme-classic/navbar.json",
+          i18nPatterns
+        )
+      ).toBe(false);
+      expect(
+        isAllowedFile(
+          "i18n/de/docusaurus-theme-classic/footer.json",
+          i18nPatterns
+        )
+      ).toBe(false);
+    });
+
     it("should still allow code.json alongside the theme exceptions", () => {
       expect(isAllowedFile("i18n/es/code.json", i18nPatterns)).toBe(true);
     });

--- a/scripts/verify-generated-content-policy.ts
+++ b/scripts/verify-generated-content-policy.ts
@@ -45,7 +45,11 @@ export const GENERATED_DIRECTORIES = [
     allowedPatterns: [
       /\.gitkeep$/,
       /\/code\.json$/, // UI translation strings are allowed
-      /^i18n\/[^/]+\/docusaurus-theme-classic\/(navbar|footer)\.json$/, // Hand-maintained theme chrome translations
+      // Hand-maintained theme chrome translations — exactly the es/pt
+      // navbar/footer files. The locale is pinned to es|pt (not a wildcard)
+      // so a force-added theme file for another locale (e.g. i18n/fr/...) is
+      // still flagged as a policy violation.
+      /^i18n\/(?:es|pt)\/docusaurus-theme-classic\/(navbar|footer)\.json$/,
     ],
   },
   {


### PR DESCRIPTION
Addresses the three review comments on #197 that were merged before being handled:

1. **greptile P2 — theme allowlist accepts every locale**: pinned the theme-chrome exception to `es|pt` (was a `[^/]+` wildcard), so `i18n/fr/docusaurus-theme-classic/navbar.json` is now flagged. Added a negative test for `fr`/`de` while the 4 es/pt navbar/footer files still pass.

2. **greptile P2 — test runs block production deploys**: scoped the concurrency group by environment — `deploy-${{ inputs.environment || 'production' }}` — so a long `environment: test` deploy can't queue/block an urgent production deploy. repository_dispatch and push (no `inputs.environment`) resolve to `production`, matching the workflow's existing production-default logic.

3. **codex P2 — add queue:max so pending deploys aren't dropped**: investigated and intentionally **not** applied. With `cancel-in-progress: false` and GitHub's default single pending slot, production deploys get latest-wins: if several are dispatched back-to-back, the in-flight one finishes then the newest queued one runs; a dropped intermediate is superseded anyway (its content SHA and Notion status update are both overtaken by the newer run). `queue: max` would only burn time deploying stale intermediate content. Documented this rationale in a comment on the concurrency block so the decision is explicit.

## Verification
- `bun scripts/verify-generated-content-policy.ts` → 0 violations, exit 0
- `bun run test:content-policy` → 19/19 pass (incl. new fr/de rejection test), under the Bun runtime
- deploy-production.yml parses

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Tightens deployment and generated-content policy behavior.
- Scopes deployment concurrency by production versus test environment while retaining latest-wins queue semantics.
- Restricts hand-maintained Docusaurus theme-file exceptions to Spanish and Portuguese.
- Adds negative tests ensuring French and German theme files remain policy violations.

<h3>Confidence Score: 5/5</h3>

PR appears safe to merge; no actionable defects identified.

Concurrency keys align with actual production and test deployment targets, while locale policy narrowing matches repository configuration, tracked files, and test coverage.

No files require additional attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the content policy test suite with Bun and confirmed it completed successfully.
- Ran the generated-content-policy verification script and confirmed repository scans completed with directory totals.
- Validated deployment concurrency checks: the parser exited with status 0 and emitted yaml\_parse=success and validation=passed.
- Reviewed the read-only Ruby parser harness used for deployment concurrency validation.

<a href="https://app.greptile.com/trex/runs/15599274/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-production.yml | Environment-scoped concurrency correctly separates test runs while keeping all production-targeting triggers serialized. |
| scripts/verify-generated-content-policy.ts | Theme-file allowlist now matches configured and tracked Spanish and Portuguese locale exceptions. |
| scripts/verify-generated-content-policy.test.ts | Adds focused rejection coverage for unsupported locale theme files while retaining intended exception coverage. |

</details>

<sub>Reviews (1): Last reviewed commit: ["ci: address #197 review feedback (locale..."](https://github.com/digidem/comapeo-docs/commit/a2f5e279c546927d8df10365164c6ec5972111b2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46713151)</sub>

<!-- /greptile_comment -->