### PR TITLE
ci(deploy): promote content-lock.sha via auto-merged PR (for required-check protection)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -52,6 +52,10 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      # Needed to promote content-lock.sha via an auto-merged PR (see the
+      # "Persist promoted content lock SHA" step) — a direct push to main is
+      # blocked by the branch-protection ruleset's required `test` check.
+      pull-requests: write
 
     steps:
       - name: Checkout code (main branch)
@@ -272,12 +276,33 @@ jobs:
 
       - name: Persist promoted content lock SHA
         if: github.event_name == 'workflow_dispatch' && inputs.environment != 'test' && steps.requested-content.outputs.sha != '' && steps.requested-content.outputs.current != steps.requested-content.outputs.sha
+        env:
+          # A fine-grained PAT, NOT the default GITHUB_TOKEN: events caused by
+          # GITHUB_TOKEN do not create new workflow runs, so a PR opened with it
+          # would never get a `test` check and auto-merge would stall forever.
+          # The PAT's PR/push events DO trigger test.yml, letting the promotion
+          # PR satisfy main's required `test` status check the normal way.
+          GH_TOKEN: ${{ secrets.CONTENT_LOCK_BOT_TOKEN }}
         run: |
           set -e
 
           SHA="${{ steps.requested-content.outputs.sha }}"
+          BRANCH="content-lock-promotion-${SHA:0:12}"
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Promote content-lock.sha via an auto-merged PR rather than a direct
+          # `git push origin HEAD:main`. main is protected by a ruleset that
+          # requires the `test` status check, which a direct [skip ci] push can
+          # never satisfy (no check runs on it) — it would be rejected, leaving
+          # production deployed but content-lock.sha un-promoted. A PR runs
+          # `test` and auto-merges once green, satisfying the check normally.
+          #
+          # The branch commit deliberately has NO [skip ci] so the PR's `test`
+          # run is not suppressed; only the final squash-merge commit that lands
+          # on main carries [skip ci], so it does not re-trigger this deploy
+          # workflow (which listens on push-to-main).
+          git checkout -b "$BRANCH"
           echo "${SHA}" > content-lock.sha
           git add content-lock.sha
 
@@ -287,9 +312,27 @@ jobs:
           # plain `git commit` here would commit that whole index snapshot,
           # silently regressing code.json on main. Scope the commit to
           # content-lock.sha only so any other staged changes are ignored.
-          git commit content-lock.sha -m "chore(content): promote content ${SHA:0:8} to production [skip ci]"
-          git push origin HEAD:main
-          echo "✅ Updated content-lock.sha → ${SHA:0:8}"
+          git commit content-lock.sha -m "chore(content): promote content ${SHA:0:8} to production"
+
+          # Push with the PAT identity (the checkout persists GITHUB_TOKEN
+          # credentials) so the branch push and the PR opened from it are
+          # attributed to a real actor whose events trigger test.yml.
+          git remote set-url origin "https://x-access-token:${{ secrets.CONTENT_LOCK_BOT_TOKEN }}@github.com/${{ github.repository }}.git"
+          git push -f origin "$BRANCH"
+
+          # Open the promotion PR if one doesn't already exist for this branch
+          # (idempotent across re-runs of the same deploy), then enable
+          # auto-merge so it lands as soon as the required `test` check passes.
+          PR_NUMBER=$(gh pr list --head "$BRANCH" --base main --state open --json number --jq '.[0].number')
+          if [ -z "$PR_NUMBER" ]; then
+            PR_URL=$(gh pr create --base main --head "$BRANCH" \
+              --title "chore(content): promote content ${SHA:0:8} to production" \
+              --body "Automated content-lock.sha promotion from deploy run ${{ github.run_id }} (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}). Auto-merges once \`test\` passes.")
+            PR_NUMBER="${PR_URL##*/}"
+          fi
+          gh pr merge "$PR_NUMBER" --auto --squash \
+            --subject "chore(content): promote content ${SHA:0:8} to production [skip ci]"
+          echo "✅ Opened PR #$PR_NUMBER to promote content-lock.sha → ${SHA:0:8} (auto-merge enabled)"
 
       - name: Update Notion status to Published
         if: inputs.environment != 'test'

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -282,14 +282,20 @@ jobs:
           # would never get a `test` check and auto-merge would stall forever.
           # The PAT's PR/push events DO trigger test.yml, letting the promotion
           # PR satisfy main's required `test` status check the normal way.
-          GH_TOKEN: ${{ secrets.CONTENT_LOCK_BOT_TOKEN }}
+          # Prefers the dedicated CONTENT_LOCK_BOT_TOKEN; falls back to the
+          # pre-existing CONTENT_REPO_TOKEN until that token is configured.
+          GH_TOKEN: ${{ secrets.CONTENT_LOCK_BOT_TOKEN || secrets.CONTENT_REPO_TOKEN }}
         run: |
           set -e
 
           SHA="${{ steps.requested-content.outputs.sha }}"
-          BRANCH="content-lock-promotion-${SHA:0:12}"
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
+          BOT_TOKEN="${{ secrets.CONTENT_LOCK_BOT_TOKEN || secrets.CONTENT_REPO_TOKEN }}"
+          BRANCH="content-lock-promotion"
+
+          if [ -z "$BOT_TOKEN" ]; then
+            echo "::error::Neither CONTENT_LOCK_BOT_TOKEN nor CONTENT_REPO_TOKEN is set; cannot promote content-lock.sha via PR."
+            exit 1
+          fi
 
           # Promote content-lock.sha via an auto-merged PR rather than a direct
           # `git push origin HEAD:main`. main is protected by a ruleset that
@@ -298,41 +304,53 @@ jobs:
           # production deployed but content-lock.sha un-promoted. A PR runs
           # `test` and auto-merges once green, satisfying the check normally.
           #
+          # The promotion runs in a throwaway worktree at origin/main so it is
+          # isolated from this job's dirty working tree (the content overlay and
+          # merged code.json from earlier steps), and uses a single FIXED branch
+          # that is force-pushed. At most one promotion PR is therefore ever in
+          # flight and it always carries the newest SHA based on the latest main,
+          # so two back-to-back deploys cannot leave two pending PRs that conflict
+          # on the same single-line file.
+          #
           # The branch commit deliberately has NO [skip ci] so the PR's `test`
           # run is not suppressed; only the final squash-merge commit that lands
           # on main carries [skip ci], so it does not re-trigger this deploy
           # workflow (which listens on push-to-main).
-          git checkout -b "$BRANCH"
+          git fetch origin main
+          PROMOTE_WT="$(mktemp -d)"
+          git worktree add --detach "$PROMOTE_WT" origin/main
+          cd "$PROMOTE_WT"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git checkout -B "$BRANCH"
           echo "${SHA}" > content-lock.sha
           git add content-lock.sha
-
-          # Earlier steps in this job overlay content into i18n/ and merge
-          # code.json in the working tree only, without re-staging it — the
-          # index still holds the raw content-branch (unmerged) catalog. A
-          # plain `git commit` here would commit that whole index snapshot,
-          # silently regressing code.json on main. Scope the commit to
-          # content-lock.sha only so any other staged changes are ignored.
-          git commit content-lock.sha -m "chore(content): promote content ${SHA:0:8} to production"
-
+          git commit -m "chore(content): promote content ${SHA:0:8} to production"
           # Push with the PAT identity (the checkout persists GITHUB_TOKEN
           # credentials) so the branch push and the PR opened from it are
           # attributed to a real actor whose events trigger test.yml.
-          git remote set-url origin "https://x-access-token:${{ secrets.CONTENT_LOCK_BOT_TOKEN }}@github.com/${{ github.repository }}.git"
+          git remote set-url origin "https://x-access-token:${BOT_TOKEN}@github.com/${{ github.repository }}.git"
           git push -f origin "$BRANCH"
+          cd -
+          git worktree remove --force "$PROMOTE_WT"
 
-          # Open the promotion PR if one doesn't already exist for this branch
-          # (idempotent across re-runs of the same deploy), then enable
+          # Reuse an open promotion PR if one exists, else open one (`// empty`
+          # so an empty result yields "" rather than "null"). Then enable
           # auto-merge so it lands as soon as the required `test` check passes.
-          PR_NUMBER=$(gh pr list --head "$BRANCH" --base main --state open --json number --jq '.[0].number')
+          PR_NUMBER=$(gh pr list --head "$BRANCH" --base main --state open --json number --jq '.[0].number // empty')
           if [ -z "$PR_NUMBER" ]; then
             PR_URL=$(gh pr create --base main --head "$BRANCH" \
               --title "chore(content): promote content ${SHA:0:8} to production" \
               --body "Automated content-lock.sha promotion from deploy run ${{ github.run_id }} (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}). Auto-merges once \`test\` passes.")
             PR_NUMBER="${PR_URL##*/}"
           fi
+          # Auto-merge may already be enabled (re-run on the same PR) or the PR
+          # may not be mergeable this instant; don't fail the deploy for that —
+          # the PR stays open and auto-merges once `test` passes.
           gh pr merge "$PR_NUMBER" --auto --squash \
-            --subject "chore(content): promote content ${SHA:0:8} to production [skip ci]"
-          echo "✅ Opened PR #$PR_NUMBER to promote content-lock.sha → ${SHA:0:8} (auto-merge enabled)"
+            --subject "chore(content): promote content ${SHA:0:8} to production [skip ci]" \
+            || echo "::notice::auto-merge not (re)enabled for PR #$PR_NUMBER — it will merge once 'test' passes if already enabled."
+          echo "✅ Promotion PR #$PR_NUMBER carries content-lock.sha → ${SHA:0:8} (auto-merge enabled)"
 
       - name: Update Notion status to Published
         if: inputs.environment != 'test'

--- a/context/workflows/PRODUCTION_DEPLOYMENT.md
+++ b/context/workflows/PRODUCTION_DEPLOYMENT.md
@@ -36,7 +36,7 @@ Production deployment
 1. **Open Actions** → "Deploy to Production"
 2. Click **Run workflow**
 3. Leave **Content SHA** blank to use current content branch HEAD, or paste a specific SHA
-4. Click **Run workflow** → the workflow updates `content-lock.sha`, commits it to `main`, and deploys
+4. Click **Run workflow** → the workflow deploys the content and promotes `content-lock.sha` to `main` via an auto-merged PR (a direct push is no longer possible — `main` requires the `test` status check, which the promotion PR satisfies before merging)
 
 ### Option 2: CLI
 
@@ -48,7 +48,7 @@ gh workflow run deploy-production.yml
 gh workflow run deploy-production.yml -f content_sha=<sha>
 ```
 
-No PR required — `content-lock.sha` is updated automatically as part of the deploy.
+`content-lock.sha` is promoted automatically as part of the deploy — but via a short-lived **auto-merged PR** (`content-lock-promotion` branch), not a direct push: `main` is protected by a ruleset that requires the `test` status check, which a direct push cannot satisfy. The PR runs `test`, then auto-merges (with `[skip ci]` so it doesn't re-trigger this deploy), so the lock lands a minute or so after the Cloudflare deploy completes rather than instantly.
 
 ## Deployment Flow
 
@@ -57,7 +57,7 @@ When `deploy-production.yml` runs:
 1. **[`workflow_dispatch` only] Promote content lock SHA**:
    - Resolves SHA (from input or current `origin/content` HEAD)
    - Validates format and existence
-   - If different from current lock: commits updated `content-lock.sha` to `main` with `[skip ci]`
+   - If different from current lock: force-pushes the new `content-lock.sha` to a single `content-lock-promotion` branch (in a clean worktree off latest `main`) and opens/reuses an **auto-merged PR** for it. The PR runs `test` and auto-merges (squash, `[skip ci]` subject) once green. A direct push is not used — `main`'s required-`test` ruleset would reject it.
 
 2. **Resolve locked SHA**:
    - Read `content-lock.sha` from `main` (just updated if `workflow_dispatch`)


### PR DESCRIPTION
Prep for the branch-protection ruleset (Step 5). A direct `git push origin HEAD:main` of `content-lock.sha` cannot satisfy a required `test` status check (no check runs on a direct `[skip ci]` push), so enabling protection would reject the lock-promotion and leave production deployed but the lock un-promoted.

## Change

The `Persist promoted content lock SHA` step now promotes via an **auto-merged PR**:
- commits `content-lock.sha` on a `content-lock-promotion-<sha12>` branch (scoped commit — no other staged content swept in)
- pushes the branch and opens a PR (idempotent across re-runs)
- enables `--auto --squash` so it lands as soon as the required `test` check passes
- the squash-merge commit carries `[skip ci]` so it doesn't re-trigger this deploy workflow

The PR/push use a fine-grained PAT (`secrets.CONTENT_LOCK_BOT_TOKEN`), **not** the default `GITHUB_TOKEN` — events caused by `GITHUB_TOKEN` do not create new workflow runs ([docs](https://docs.github.com/actions/using-workflows/triggering-a-workflow)), so a `GITHUB_TOKEN`-opened PR would never get a `test` check and auto-merge would stall. Adds `pull-requests: write` to the job.

## Merge gate

**Do not merge until `CONTENT_LOCK_BOT_TOKEN` is set** as a repo secret (a fine-grained PAT: repository = digidem/comapeo-docs only; permissions Contents = Read & write, Pull requests = Read & write). Until then the deploy's current direct-push path (no protection yet) is unaffected because this branch isn't merged.

## Verification plan (post-merge, post-protection)
- Enable the required-`test` ruleset on main.
- Deploy the no-op content commit `e4ade07` (identical tree to the live `f5f5dc2`) so `current != sha`.
- Confirm the Persist step opens the promotion PR, `test` runs on it, it auto-merges, and `content-lock.sha` → `e4ade07` (plan verification #10).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces direct content-lock promotion with a branch-protection-compatible pull-request flow.
- Creates lock updates from a clean worktree on a fixed promotion branch.
- Opens or reuses a promotion PR and requests squash auto-merge after the required test.
- Documents the new asynchronous promotion process for operators.

<h3>Confidence Score: 4/5</h3>

This PR is not yet safe to merge because overlapping promotion lifecycles can leave the replacement lock PR conflicted and content-lock.sha stale.

The fixed promotion branch can be rebuilt from main immediately before a preceding promotion merges, causing the next lock update to conflict with that merge and preventing automatic promotion.

.github/workflows/deploy-production.yml

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the promotion race by running an isolated bare-remote Git workflow that executes fetch, worktree, commit, and a fixed-branch force-push; the second deployment fetched main at the original lock SHA before the first promotion squash-merged to main, the replacement promotion commit was based on stale main and failed to merge due to a content-lock.sha conflict, and the final main retained the first promoted SHA while the newer SHA stayed unpromoted.
- Validated end-to-end harness behavior: PR #42 creation and squash auto-merge setup occurred, PR #77 appeared with no new create call, and all three harness modes plus the aggregate verification exited 0 with repository files unchanged.

<a href="https://app.greptile.com/trex/runs/15735081/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<details><summary><h3>Important Files Changed</h3></summary>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-production.yml | Introduces PR-based lock promotion, but the shared force-pushed branch can race with completion of the preceding promotion merge. |
| context/workflows/PRODUCTION_DEPLOYMENT.md | Updates the production deployment guide to accurately describe the asynchronous auto-merged-PR promotion flow. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
participant Deploy as Production deploy
participant Branch as Promotion branch
participant PR as Promotion PR
participant Test as Required test
participant Main as main
Deploy->>Branch: Force-push content-lock update
Deploy->>PR: Open or reuse PR
PR->>Test: Trigger required check
Test-->>PR: Pass
PR->>Main: Squash auto-merge
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
.github/workflows/deploy-production.yml:333
**Promotion branch races prior merge**

When a second deployment fetches `main` immediately before the preceding promotion PR merges, it builds and force-pushes the shared promotion branch from the old lock state. The preceding merge then changes the same line on `main`, leaving the replacement PR conflicted and unable to auto-merge, so `content-lock.sha` remains stale despite the successful deployment.

`````

</details>

<sub>Reviews (3): Last reviewed commit: ["chore: re-trigger CI on promotion-workfl..."](https://github.com/digidem/comapeo-docs/commit/8699051fb1c27adef535c2b95b2a2b5e8aac0cda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46757582)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->