### PR TITLE
ci(deploy): retry enabling auto-merge on the promotion PR

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -344,13 +344,27 @@ jobs:
               --body "Automated content-lock.sha promotion from deploy run ${{ github.run_id }} (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}). Auto-merges once \`test\` passes.")
             PR_NUMBER="${PR_URL##*/}"
           fi
-          # Auto-merge may already be enabled (re-run on the same PR) or the PR
-          # may not be mergeable this instant; don't fail the deploy for that —
-          # the PR stays open and auto-merges once `test` passes.
-          gh pr merge "$PR_NUMBER" --auto --squash \
-            --subject "chore(content): promote content ${SHA:0:8} to production [skip ci]" \
-            || echo "::notice::auto-merge not (re)enabled for PR #$PR_NUMBER — it will merge once 'test' passes if already enabled."
-          echo "✅ Promotion PR #$PR_NUMBER carries content-lock.sha → ${SHA:0:8} (auto-merge enabled)"
+          # Enable auto-merge so the PR lands as soon as the required `test`
+          # check passes. GitHub computes a freshly-created/pushed PR's
+          # mergeability asynchronously, and `gh pr merge --auto` errors until
+          # it is ready — so retry briefly instead of either failing the deploy
+          # or silently leaving auto-merge disabled (which would strand the lock
+          # under branch protection).
+          auto_merge_enabled=false
+          for attempt in 1 2 3 4 5 6; do
+            if gh pr merge "$PR_NUMBER" --auto --squash \
+                --subject "chore(content): promote content ${SHA:0:8} to production [skip ci]" 2>/tmp/automerge.err; then
+              auto_merge_enabled=true
+              break
+            fi
+            echo "::notice::auto-merge not ready for PR #$PR_NUMBER (attempt $attempt): $(head -1 /tmp/automerge.err 2>/dev/null)"
+            sleep 10
+          done
+          if [ "$auto_merge_enabled" = "true" ]; then
+            echo "✅ Promotion PR #$PR_NUMBER carries content-lock.sha → ${SHA:0:8} (auto-merge enabled)"
+          else
+            echo "::warning::Could not enable auto-merge for PR #$PR_NUMBER after retries — merge it manually once 'test' passes to promote content-lock.sha → ${SHA:0:8}."
+          fi
 
       - name: Update Notion status to Published
         if: inputs.environment != 'test'


### PR DESCRIPTION
Follow-up to #199. `gh pr merge --auto` errors until GitHub finishes computing a freshly-created PR's mergeability, so the single attempt right after `gh pr create` can fail — silently leaving auto-merge **disabled** and stranding `content-lock.sha` under branch protection.

Observed live on the `e4ade07` promotion (PR #200): the in-step `gh pr merge --auto` failed and auto-merge had to be re-enabled by hand before it merged.

Fix: retry the enable up to ~60s (6 × 10s) before falling back to a `::warning::` to merge manually, so the promotion lands autonomously once `test` passes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds bounded retries when enabling auto-merge on content-lock promotion PRs, reports successful enablement accurately, and emits a manual-merge warning after retries are exhausted.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable regression identified in the changed workflow.

The retry loop is compatible with the Ubuntu runner, correctly handles command failures without aborting the deployment, and improves the existing failure path by warning operators when auto-merge remains disabled.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex produced a proof for the posted P1 finding and linked it to the review comment.
- T-Rex validated the general-contract-validation-proof by confirming the transient proof where HEAD invoked gh six times and recorded five sleeps, and by confirming the exhaustion proof where six gh invocations were followed by a sixth sleep with no retry before warning; a fake gh becoming ready after that sixth interval was never followed by a seventh invocation.

<a href="https://app.greptile.com/trex/runs/15736113/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<details><summary><h3>Important Files Changed</h3></summary>




| Filename | Overview |
|----------|----------|
| .github/workflows/deploy-production.yml | Replaces the single best-effort auto-merge attempt with a compatible six-attempt retry loop and explicit success/failure reporting. |

</details>


<!-- greptile_failed_comments -->
<details open><summary><h3>Comments Outside Diff (1)</h3></summary>

1. General comment 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **The sixth 10-second wait is not followed by a retry**

   - **Bug**
     - The loop provides six total merge attempts rather than six retries at 10-second intervals. A success on invocation 6 works after only five waits. If all six invocations fail, the block sleeps for the sixth time and then immediately warns without checking `gh` again. Consequently, mergeability becoming ready during the final advertised interval is missed.
   - **Cause**
     - `sleep 10` runs unconditionally after every failed attempt, including attempt 6, while the loop contains only six invocations. This creates five useful retry intervals plus one ineffective trailing wait.
   - **Fix**
     - Treat the first invocation separately and perform up to six sleep-and-retry cycles, for seven total `gh pr merge` invocations, or skip sleeping after attempt 6 and describe the behavior as six total attempts/five retry intervals.

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["ci(deploy): retry enabling auto-merge on..."](https://github.com/digidem/comapeo-docs/commit/3d788f12896c913113b264776c8b420b652d6892) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46983725)</sub>

<!-- /greptile_comment -->